### PR TITLE
Tigerbrew portable formulae

### DIFF
--- a/Formula/portable-curl.rb
+++ b/Formula/portable-curl.rb
@@ -1,0 +1,53 @@
+require File.expand_path("../../Abstract/portable-formula", __FILE__)
+
+class PortableCurl < PortableFormula
+  desc "Portable curl"
+  homepage "https://curl.haxx.se/"
+  url "https://curl.haxx.se/download/curl-7.58.0.tar.bz2"
+  mirror "http://curl.askapache.com/download/curl-7.58.0.tar.bz2"
+  sha256 "1cb081f97807c01e3ed747b6e1c9fee7a01cb10048f1cd0b5f56cfe0209de731"
+
+  depends_on "pkg-config" => :build
+  depends_on "portable-openssl" => :build
+
+  resource "curl-ca-bundle" do
+    url "https://curl.haxx.se/ca/cacert-2018-01-17.pem"
+    sha256 "defe310a0184a12e4b1b3d147f1d77395dd7a09e3428373d019bef5d542ceba3"
+  end
+
+  def install
+    resource("curl-ca-bundle").stage do
+      share.install "cacert-2018-01-17.pem" => "cacert.pem"
+    end
+
+    args = %W[
+      --disable-debug
+      --disable-dependency-tracking
+      --disable-silent-rules
+      --prefix=#{prefix}
+      --bindir=#{libexec}
+      --enable-static
+      --disable-shared
+    ]
+
+    args << "--with-ssl=#{Formula["portable-openssl"].opt_prefix}"
+    ENV.prepend_path "PKG_CONFIG_PATH", "#{Formula["portable-openssl"].opt_lib}/pkgconfig"
+
+    system "./configure", *args
+    system "make", "install"
+    (bin/"curl").write <<~EOS
+    #!/bin/sh
+
+    SCRIPTPATH="$( cd "$(dirname "$0")" ; pwd -P )"
+    exec "${SCRIPTPATH}/../libexec/curl" --cacert "${SCRIPTPATH}/../share/cacert.pem" "$@"
+    EOS
+  end
+
+  test do
+    # Fetch the curl tarball and see that the checksum matches.
+    # This requires a network connection, but so does Homebrew in general.
+    filename = (testpath/"test.tar.gz")
+    system "#{bin}/curl", "-L", stable.url, "-o", filename
+    filename.verify_checksum stable.checksum
+  end
+end

--- a/Formula/portable-expat.rb
+++ b/Formula/portable-expat.rb
@@ -3,9 +3,8 @@ require File.expand_path("../../Abstract/portable-formula", __FILE__)
 class PortableExpat < PortableFormula
   desc "Portable expat"
   homepage "http://www.libexpat.org"
-  url "https://downloads.sourceforge.net/project/expat/expat/2.2.0/expat-2.2.0.tar.bz2"
-  mirror "https://fossies.org/linux/www/expat-2.2.0.tar.bz2"
-  sha256 "d9e50ff2d19b3538bd2127902a89987474e1a4db8e43a66a4d1a712ab9a504ff"
+  url "https://downloads.sourceforge.net/project/expat/expat/2.2.5/expat-2.2.5.tar.bz2"
+  sha256 "d9dc32efba7e74f788fcc4f212a43216fc37cf5f23f4c2339664d473353aedf6"
 
   def install
     ENV.universal_binary if build.with? "universal"

--- a/Formula/portable-expat.rb
+++ b/Formula/portable-expat.rb
@@ -1,0 +1,64 @@
+require File.expand_path("../../Abstract/portable-formula", __FILE__)
+
+class PortableExpat < PortableFormula
+  desc "Portable expat"
+  homepage "http://www.libexpat.org"
+  url "https://downloads.sourceforge.net/project/expat/expat/2.2.0/expat-2.2.0.tar.bz2"
+  mirror "https://fossies.org/linux/www/expat-2.2.0.tar.bz2"
+  sha256 "d9e50ff2d19b3538bd2127902a89987474e1a4db8e43a66a4d1a712ab9a504ff"
+
+  def install
+    ENV.universal_binary if build.with? "universal"
+    system "./configure", "--disable-dependency-tracking",
+                          "--prefix=#{prefix}",
+                          "--enable-static",
+                          "--disable-shared"
+    system "make", "install"
+  end
+
+  test do
+    cp_r Dir["#{prefix}/*"], testpath
+    (testpath/"test.xml").write <<~EOS
+      <?xml version="1.0" standalone="yes"?>
+      <str>Hello, world!</str>
+    EOS
+    system testpath/"bin/xmlwf", "test.xml"
+
+    (testpath/"test.c").write <<~EOS
+      #include <stdio.h>
+      #include "expat.h"
+
+      static void XMLCALL my_StartElementHandler(
+        void *userdata,
+        const XML_Char *name,
+        const XML_Char **atts)
+      {
+        printf("tag:%s|", name);
+      }
+
+      static void XMLCALL my_CharacterDataHandler(
+        void *userdata,
+        const XML_Char *s,
+        int len)
+      {
+        printf("data:%.*s|", len, s);
+      }
+
+      int main()
+      {
+        static const char str[] = "<str>Hello, world!</str>";
+        int result;
+
+        XML_Parser parser = XML_ParserCreate("utf-8");
+        XML_SetElementHandler(parser, my_StartElementHandler, NULL);
+        XML_SetCharacterDataHandler(parser, my_CharacterDataHandler);
+        result = XML_Parse(parser, str, sizeof(str), 1);
+        XML_ParserFree(parser);
+
+        return result;
+      }
+    EOS
+    system ENV.cc, "test.c", "-I#{include}", "-L#{lib}", "-lexpat", "-o", "test"
+    assert_equal "tag:str|data:Hello, world!|", shell_output("./test")
+  end
+end

--- a/Formula/portable-expat.rb
+++ b/Formula/portable-expat.rb
@@ -4,6 +4,7 @@ class PortableExpat < PortableFormula
   desc "Portable expat"
   homepage "http://www.libexpat.org"
   url "https://downloads.sourceforge.net/project/expat/expat/2.2.5/expat-2.2.5.tar.bz2"
+  mirror "https://fossies.org/linux/www/expat-2.2.5.tar.bz2"
   sha256 "d9dc32efba7e74f788fcc4f212a43216fc37cf5f23f4c2339664d473353aedf6"
 
   def install

--- a/Formula/portable-git.rb
+++ b/Formula/portable-git.rb
@@ -27,7 +27,16 @@ class PortableGit < PortableFormula
     end
   end
 
+  resource "curl-ca-bundle" do
+    url "https://curl.haxx.se/ca/cacert-2018-01-17.pem"
+    sha256 "defe310a0184a12e4b1b3d147f1d77395dd7a09e3428373d019bef5d542ceba3"
+  end
+
   def install
+    resource("curl-ca-bundle").stage do
+      libexec.install "cacert-2018-01-17.pem" => "cert.pem"
+    end
+
     if OS.mac? && MacOS.version < :leopard
       tar = Formula["gnu-tar"]
       tab = Tab.for_keg tar.installed_prefix

--- a/Formula/portable-git.rb
+++ b/Formula/portable-git.rb
@@ -84,7 +84,6 @@ class PortableGit < PortableFormula
       GIT_LIBEXEC="$(cd "${0%/*}/.." && pwd -P)/libexec"
       GIT_SSL_CAINFO="$GIT_LIBEXEC/cert.pem" exec "$GIT_LIBEXEC/bin/git" "$@"
     EOS
-    cp curl.opt_libexec/"cert.pem", libexec/"cert.pem"
   end
 
   test do

--- a/Formula/portable-git.rb
+++ b/Formula/portable-git.rb
@@ -3,8 +3,8 @@ require File.expand_path("../../Abstract/portable-formula", __FILE__)
 class PortableGit < PortableFormula
   desc "Portable git"
   homepage "https://git-scm.com"
-  url "https://www.kernel.org/pub/software/scm/git/git-2.12.2.tar.xz"
-  sha256 "d21a9e23506e618d561fb25a8a7bd6134f927b86147930103487117a7a678c4a"
+  url "https://www.kernel.org/pub/software/scm/git/git-2.16.2.tar.xz"
+  sha256 "5560578bd21468d98637f41515c165d32f69caff0838b8989dee5ce10022c717"
 
   if OS.mac? && MacOS.version < :leopard
     # system tar has odd permissions errors

--- a/Formula/portable-git.rb
+++ b/Formula/portable-git.rb
@@ -1,0 +1,87 @@
+require File.expand_path("../../Abstract/portable-formula", __FILE__)
+
+class PortableGit < PortableFormula
+  desc "Portable git"
+  homepage "https://git-scm.com"
+  url "https://www.kernel.org/pub/software/scm/git/git-2.12.2.tar.xz"
+  sha256 "d21a9e23506e618d561fb25a8a7bd6134f927b86147930103487117a7a678c4a"
+
+  if OS.mac? && MacOS.version < :leopard
+    # system tar has odd permissions errors
+    depends_on "gnu-tar" => :build
+  end
+
+  depends_on "portable-curl" => :build
+  if OS.linux? || OS::Mac.version < :leopard
+    depends_on "portable-expat" => :build
+  end
+
+  depends_on "portable-openssl" => :build
+  depends_on "portable-zlib" => :build if OS.linux?
+
+  # ld64 understands -rpath but rejects it on Tiger
+  if OS.mac? && MacOS.version < :leopard
+    patch :p1 do
+      url "https://trac.macports.org/export/106975/trunk/dports/devel/git-core/files/patch-Makefile.diff"
+      sha256 "6d1484c7ed726525b0f01e2da1a22311c371d48965435d67bcee844a9995d956"
+    end
+  end
+
+  def install
+    if OS.mac? && MacOS.version < :leopard
+      tar = Formula["gnu-tar"]
+      tab = Tab.for_keg tar.installed_prefix
+      tar_name = tab.used_options.include?("--with-default-names") ? tar.bin/"tar" : tar.bin/"gtar"
+      inreplace "Makefile" do |s|
+        s.change_make_var! "TAR", tar_name.to_s
+      end
+    end
+
+    curl = Formula["portable-curl"]
+    expat = Formula["portable-expat"]
+    zlib = Formula["portable-zlib"]
+
+    ENV.universal_binary if build.with? "universal"
+
+    # Git Makefile doesn't support to link static libcurl.
+    inreplace "Makefile", "$(CURL_LIBCURL)", `#{curl.opt_bin/"curl-config"} --static-libs`.chomp
+    ENV.append "LDFLAGS", "-L#{zlib.opt_prefix}/lib" if OS.linux?
+
+    # If these things are installed, tell Git build system to not use them
+    ENV["NO_FINK"] = "1"
+    ENV["NO_DARWIN_PORTS"] = "1"
+    ENV["V"] = "1" # build verbosely
+    ENV["NO_R_TO_GCC_LINKER"] = "1" # pass arguments to LD correctly
+    ENV["PYTHON_PATH"] = which "python"
+    ENV["PERL_PATH"] = which "perl"
+    ENV["NO_PERL_MAKEMAKER"] = "1"
+    ENV["NO_GETTEXT"] = "1"
+    ENV["NO_TCLTK"] = "1"
+    if OS.linux? || OS::Mac.version < :leopard
+      ENV["EXPATDIR"] = expat.opt_prefix
+    end
+    args = %W[
+      prefix=#{prefix}
+      CC=#{ENV.cc}
+      CFLAGS=#{ENV.cflags}
+      LDFLAGS=#{ENV.ldflags}
+    ]
+    system "make", "install", *args
+
+    (libexec/"bin").mkpath
+    (libexec/"bin").install bin/"git"
+    (bin/"git").write <<~EOS
+      #!/bin/bash
+      GIT_LIBEXEC="$(cd "${0%/*}/.." && pwd -P)/libexec"
+      GIT_SSL_CAINFO="$GIT_LIBEXEC/cert.pem" exec "$GIT_LIBEXEC/bin/git" "$@"
+    EOS
+    cp curl.opt_libexec/"cert.pem", libexec/"cert.pem"
+  end
+
+  test do
+    cp_r Dir["#{prefix}/*"], testpath
+    ENV["PATH"] = "/usr/bin:/bin"
+    ENV["GIT_CURL_VERBOSE"] = "1"
+    system testpath/"bin/git", "clone", "https://github.com/isaacs/github"
+  end
+end

--- a/Formula/portable-git.rb
+++ b/Formula/portable-git.rb
@@ -44,7 +44,7 @@ class PortableGit < PortableFormula
     ENV.universal_binary if build.with? "universal"
 
     # Git Makefile doesn't support to link static libcurl.
-    inreplace "Makefile", "$(CURL_LIBCURL)", `#{curl.opt_bin/"curl-config"} --static-libs`.chomp
+    inreplace "Makefile", "$(CURL_LIBCURL)", `#{curl.opt_libexec/"curl-config"} --static-libs`.chomp
     ENV.append "LDFLAGS", "-L#{zlib.opt_prefix}/lib" if OS.linux?
 
     # If these things are installed, tell Git build system to not use them

--- a/Formula/portable-git.rb
+++ b/Formula/portable-git.rb
@@ -86,7 +86,10 @@ class PortableGit < PortableFormula
     (libexec/"bin").install bin/"git"
     (bin/"git").write <<~EOS
       #!/bin/bash
-      GIT_LIBEXEC="$(cd "${0%/*}/.." && pwd -P)/libexec"
+      GIT_DIR="$(cd "${0%/*}/.." && pwd -P)"
+      GIT_LIBEXEC="$GIT_DIR/libexec"
+      export GIT_TEMPLATE_DIR="$GIT_DIR/share/git-core/templates"
+      export GIT_EXEC_PATH="$GIT_LIBEXEC/git-core"
       GIT_SSL_CAINFO="$GIT_LIBEXEC/cert.pem" exec "$GIT_LIBEXEC/bin/git" "$@"
     EOS
   end

--- a/Formula/portable-git.rb
+++ b/Formula/portable-git.rb
@@ -75,6 +75,11 @@ class PortableGit < PortableFormula
       CFLAGS=#{ENV.cflags}
       LDFLAGS=#{ENV.ldflags}
     ]
+    # git no longer builds with openssl's SHA1 implementation by default; however,
+    # git's builtin DC_SHA1 implementation seems to have issues on PPC and/or on
+    # gcc-4.2 on PPC, leading it to calculate wrong SHA1s.
+    # We're using openssl anyway; let's use its SHA1.
+    args << "OPENSSL_SHA1=1"
     system "make", "install", *args
 
     (libexec/"bin").mkpath


### PR DESCRIPTION
This adds several formulae which are actively used by Tigerbrew.

The portable curl is used since an increasing number of servers require TLS 1.2 or later, including GitHub. Even ignoring certs, older systems' curls can't fetch from there. After experimenting with a bunch of solutions, including using Tigerbrew's curl package to fetch, I've landed on using a vendored curl with an embedded set of certs as the easiest solution which prevents most forms of user error. This package is also used in the Tigerbrew installer, since most systems that will be installing Tigerbrew don't have a usable git and can't fetch a tarball from GitHub using the system curl.

The expat and git packages are part of an experiment with vendoring a TLS 1.2-compatible git, both for `brew update` and possibly for use in the installer. I've encountered a few issues with users whose systems end up in weird states and whose gits can't switch branches; this may provide a usable solution for that. It may also provide a preferable way to pull down Tigerbrew from GitHub in the installer, instead of using the portable curl.

The commit history is a bit of a mess, but I can clean this up.