### PR TITLE
portable-ruby: match Apple’s Ruby options.

### DIFF
--- a/Formula/portable-ncurses.rb
+++ b/Formula/portable-ncurses.rb
@@ -3,20 +3,11 @@ require File.expand_path("../../Abstract/portable-formula", __FILE__)
 class PortableNcurses < PortableFormula
   desc "Portable ncurses"
   homepage "https://www.gnu.org/s/ncurses/"
-  url "https://ftpmirror.gnu.org/ncurses/ncurses-6.0.tar.gz"
-  mirror "https://ftp.gnu.org/gnu/ncurses/ncurses-6.0.tar.gz"
-  sha256 "f551c24b30ce8bfb6e96d9f59b42fbea30fa3a6123384172f9e7284bcf647260"
-  revision 1
+  url "https://ftp.gnu.org/gnu/ncurses/ncurses-6.1.tar.gz"
+  mirror "https://ftpmirror.gnu.org/ncurses/ncurses-6.1.tar.gz"
+  sha256 "aa057eeeb4a14d470101eff4597d5833dcef5965331be3528c08d99cebaa0d17"
 
   depends_on "pkg-config" => :build
-
-  # stable rollup patch created by upstream see
-  # http://invisible-mirror.net/archives/ncurses/6.0/README
-  resource "ncurses-6.0-20160910-patch.sh" do
-    url "http://invisible-mirror.net/archives/ncurses/6.0/ncurses-6.0-20160910-patch.sh.bz2"
-    mirror "https://www.mirrorservice.org/sites/lynx.invisible-island.net/ncurses/6.0/ncurses-6.0-20160910-patch.sh.bz2"
-    sha256 "f570bcfe3852567f877ee6f16a616ffc7faa56d21549ad37f6649022f8662538"
-  end
 
   def install
     ENV.universal_binary if build.with? "universal"
@@ -29,10 +20,6 @@ class PortableNcurses < PortableFormula
     ENV.append "CPPFLAGS", "-P"
 
     (lib/"pkgconfig").mkpath
-
-    # stage and apply patch
-    buildpath.install resource("ncurses-6.0-20160910-patch.sh")
-    system "sh", "ncurses-6.0-20160910-patch.sh"
 
     system "./configure", "--disable-dependency-tracking",
                           "--prefix=#{prefix}",

--- a/Formula/portable-openssl.rb
+++ b/Formula/portable-openssl.rb
@@ -3,9 +3,11 @@ require File.expand_path("../../Abstract/portable-formula", __FILE__)
 class PortableOpenssl < PortableFormula
   desc "Portable OpenSSL"
   homepage "https://openssl.org/"
-  url "https://www.openssl.org/source/openssl-1.0.2l.tar.gz"
-  mirror "https://dl.bintray.com/homebrew/mirror/openssl-1.0.2l.tar.gz"
-  sha256 "ce07195b659e75f4e1db43552860070061f156a98bb37b672b101ba6e3ddf30c"
+  url "https://www.openssl.org/source/openssl-1.0.2o.tar.gz"
+  mirror "https://dl.bintray.com/homebrew/mirror/openssl-1.0.2o.tar.gz"
+  mirror "https://www.mirrorservice.org/sites/ftp.openssl.org/source/openssl-1.0.2o.tar.gz"
+  mirror "http://artfiles.org/openssl.org/source/openssl-1.0.2o.tar.gz"
+  sha256 "ec3f5c9714ba0fd45cb4e087301eb1336c317e0d20b575a125050470e8089e4d"
 
   depends_on "makedepend" => :build
   depends_on "portable-zlib" => :build if OS.linux?

--- a/Formula/portable-ruby.rb
+++ b/Formula/portable-ruby.rb
@@ -7,6 +7,7 @@ class PortableRuby < PortableFormula
   url "https://cache.ruby-lang.org/pub/ruby/2.3/ruby-2.3.3.tar.bz2"
   mirror "http://cache.ruby-lang.org/pub/ruby/2.3/ruby-2.3.3.tar.bz2"
   sha256 "882e6146ed26c6e78c02342835f5d46b86de95f0dc4e16543294bc656594cc5b"
+  revision 1
 
   bottle do
     cellar :any_skip_relocation
@@ -82,10 +83,10 @@ class PortableRuby < PortableFormula
       --prefix=#{prefix}
       --enable-load-relative
       --with-static-linked-ext
-      --with-out-ext=tk,sdbm,gdbm,dbm,dl,fiddle
+      --with-out-ext=tk
       --disable-install-doc
       --disable-install-rdoc
-      --disable-dtrace
+      --disable-dependency-tracking
     ]
 
     if OS.mac?
@@ -95,7 +96,11 @@ class PortableRuby < PortableFormula
         ENV.replace_in_cflags(/-march=\S*/, "-Xarch_i386 \\0")
         ENV.replace_in_cflags(/-mcpu=\S*/, "-Xarch_ppc \\0")
       end
+
       args << "--with-arch=#{archs.join(",")}"
+
+      # DTrace support doesn't build on 10.5 :(
+      args << "--disable-dtrace"
     end
 
     paths = [


### PR DESCRIPTION
Also, while we're here, bump ncurses and openssl.