### PR TITLE
portable-ruby: verify dbm inclusion.

### DIFF
--- a/Formula/portable-ruby.rb
+++ b/Formula/portable-ruby.rb
@@ -163,6 +163,7 @@ class PortableRuby < PortableFormula
       shell_output("#{ruby} -ropenssl -e 'puts OpenSSL::Digest::SHA256.hexdigest(\"\")'").strip
     assert_match "200",
       shell_output("#{ruby} -ropen-uri -e 'open(\"https://google.com\") { |f| puts f.status.first }'").strip
+    system "#{ruby}", "-rdbm", "-e", "DBM.new('test')"
     system testpath/"bin/gem", "environment"
     system testpath/"bin/gem", "install", "bundler"
     system testpath/"bin/bundle", "init"


### PR DESCRIPTION
This should be possible to be required from Ruby (and we need it for https://github.com/Homebrew/brew/pull/3720).