### PR TITLE
portable-ruby: Add --without-gmp

### DIFF
--- a/Formula/portable-ruby.rb
+++ b/Formula/portable-ruby.rb
@@ -83,6 +83,7 @@ class PortableRuby < PortableFormula
       --enable-load-relative
       --with-static-linked-ext
       --with-out-ext=tk
+      --without-gmp
       --disable-install-doc
       --disable-install-rdoc
       --disable-dependency-tracking


### PR DESCRIPTION
`ruby` will be linked oportunistically against `libgmp` if it's available when Ruby is configured.