### PR TITLE
Deprecate pre-Mavericks.

### DIFF
--- a/Abstract/portable-formula.rb
+++ b/Abstract/portable-formula.rb
@@ -1,22 +1,13 @@
 module PortableFormulaMixin
   def install
     if OS.mac?
-      tag = Hardware::CPU.ppc? ? :tiger : :leopard
-      if OS::Mac.version > tag
+      if OS::Mac.version > :mavericks
         opoo <<~EOS
           You are building portable formula on #{OS::Mac.version}.
-          As result, formula won't be able to work for macOS at lower version.
-          It's recommended to build this formula on OS X #{tag.capitalize}.
+          As result, formula won't be able to work on older macOS versions.
+          It's recommended to build this formula on OS X Mavericks (the oldest version
+          that can run Homebrew).
         EOS
-      end
-
-      # Overrideable per-formula, but try to make sure our universal
-      # arches make it into the environment.
-      # This is important because in some environments (e.g. 10.4/10.5)
-      # our arches differ from the usual defaults.
-      if build.with?("universal")
-        ENV.permit_arch_flags
-        ENV.append_to_cflags archs.map { |a| "-arch #{a}" }.join(" ")
       end
 
       # Always prefer to linking to portable libs.
@@ -36,8 +27,8 @@ module PortableFormulaMixin
   end
 
   def test
-    assert_no_match /Homebrew libraries/,
-      shell_output("#{HOMEBREW_BREW_FILE} linkage #{full_name}")
+    assert_no_match(/Homebrew libraries/,
+      shell_output("#{HOMEBREW_BREW_FILE} linkage #{full_name}"))
 
     super
   end
@@ -48,34 +39,7 @@ class PortableFormula < Formula
     subclass.class_eval do
       keg_only "portable formulae are keg-only"
 
-      option "without-universal", "Don't build a universal binary" if OS.mac?
-
       prepend PortableFormulaMixin
-    end
-  end
-
-  def archs
-    # On Tiger override the default behaviour.
-    # Normally we don't build 64-bit there, because the linker is
-    # temperamental, and so "universal" builds don't usually happen.
-    # However, for the purposes of distributing portable packages,
-    # it's very useful to be able to build i386/ppc binaries for use
-    # on both Intel and PowerPC Macs. The Apple-provided compilers
-    # are capable of this on both Intel and PowerPC hosts.
-    if OS.mac? && OS::Mac.version < :leopard
-      if build.with? "universal"
-        return [:i386, :ppc]
-      else
-        return [Hardware::CPU.arch_32_bit]
-      end
-    end
-
-    if build.with? "universal"
-      Hardware::CPU.universal_archs
-    elsif OS::Mac.prefer_64_bit?
-      [Hardware::CPU.arch_64_bit]
-    else
-      [Hardware::CPU.arch_32_bit]
     end
   end
 end

--- a/Formula/portable-libyaml.rb
+++ b/Formula/portable-libyaml.rb
@@ -12,7 +12,6 @@ class PortableLibyaml < PortableFormula
   depends_on "libtool" => :build
 
   def install
-    ENV.universal_binary if build.with? "universal"
     system "./bootstrap"
     system "./configure", "--disable-dependency-tracking",
                           "--prefix=#{prefix}",

--- a/Formula/portable-ncurses.rb
+++ b/Formula/portable-ncurses.rb
@@ -10,17 +10,6 @@ class PortableNcurses < PortableFormula
   depends_on "pkg-config" => :build
 
   def install
-    ENV.universal_binary if build.with? "universal"
-
-    # Fix the build for GCC 5.1
-    # error: expected ')' before 'int' in definition of macro 'mouse_trafo'
-    # See http://lists.gnu.org/archive/html/bug-ncurses/2014-07/msg00022.html
-    # and http://trac.sagemath.org/ticket/18301
-    # Disable linemarker output of cpp
-    ENV.append "CPPFLAGS", "-P"
-
-    (lib/"pkgconfig").mkpath
-
     system "./configure", "--disable-dependency-tracking",
                           "--prefix=#{prefix}",
                           "--enable-static",

--- a/Formula/portable-readline.rb
+++ b/Formula/portable-readline.rb
@@ -3,27 +3,13 @@ require File.expand_path("../../Abstract/portable-formula", __FILE__)
 class PortableReadline < PortableFormula
   desc "Library for command-line editing"
   homepage "https://tiswww.case.edu/php/chet/readline/rltop.html"
-  url "https://ftpmirror.gnu.org/readline/readline-7.0.tar.gz"
-  mirror "https://ftp.gnu.org/gnu/readline/readline-7.0.tar.gz"
-  version "7.0.3"
-  sha256 "750d437185286f40a369e1e4f4764eda932b9459b5ec9a731628393dd3d32334"
-
-  %w[
-    001 9ac1b3ac2ec7b1bf0709af047f2d7d2a34ccde353684e57c6b47ebca77d7a376
-    002 8747c92c35d5db32eae99af66f17b384abaca961653e185677f9c9a571ed2d58
-    003 9e43aa93378c7e9f7001d8174b1beb948deefa6799b6f581673f465b7d9d4780
-  ].each_slice(2) do |p, checksum|
-    patch :p0 do
-      url "https://ftpmirror.gnu.org/readline/readline-7.0-patches/readline70-#{p}"
-      mirror "https://ftp.gnu.org/gnu/readline/readline-7.0-patches/readline70-#{p}"
-      sha256 checksum
-    end
-  end
+  url "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz"
+  mirror "https://ftp.gnu.org/gnu/readline/readline-8.0.tar.gz"
+  sha256 "e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461"
 
   depends_on "portable-ncurses" => :build if OS.linux?
 
   def install
-    ENV.universal_binary if build.with? "universal"
     system "./configure", "--prefix=#{prefix}",
                           "--enable-multibyte",
                           "--enable-static",

--- a/Formula/portable-ruby.rb
+++ b/Formula/portable-ruby.rb
@@ -10,6 +10,7 @@ class PortableRuby < PortableFormula
 
   bottle do
     cellar :any_skip_relocation
+    sha256 "539ae571968fc74d4ec3a839cb33edc5786c219a5e6ae7fb6a09ec5fc1b04e4e" => :mavericks
     sha256 "9df214085a0e566a580eea3dd9eab14a2a94930ff74fbf97fb1284e905c8921d" => :x86_64_linux
   end
 

--- a/Formula/portable-zlib.rb
+++ b/Formula/portable-zlib.rb
@@ -15,7 +15,6 @@ class PortableZlib < PortableFormula
   end
 
   def install
-    ENV.universal_binary if build.with? "universal"
     system "./configure", "--static", "--prefix=#{prefix}"
     system "make", "install"
   end

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,9 +1,11 @@
 jobs:
 - job: macOS
   pool:
-    vmImage: xcode9-macos10.13
+    vmImage: macOS-10.13
   steps:
     - bash: |
+        set -e
+        sudo xcode-select --switch /Applications/Xcode_10.1.app/Contents/Developer
         export HOMEBREW_DEVELOPER=1
         export HOMEBREW_NO_AUTO_UPDATE=1
         brew update-reset
@@ -16,17 +18,10 @@ jobs:
     vmImage: ubuntu-16.04
   steps:
     - bash: |
-        export HOMEBREW_DEVELOPER=1
-        export HOMEBREW_NO_AUTO_UPDATE=1
-        export HOMEBREW_BUILD_FROM_SOURCE=1
-        HOME="/home/linuxbrew"
-        sudo mkdir "$HOME"
-        sudo chown "$USER:" "$HOME"
-        git clone --depth=1 https://github.com/Linuxbrew/brew "$HOME/.linuxbrew/Homebrew"
-        mkdir "$HOME/.linuxbrew/bin"
-        ln -s ../Homebrew/bin/brew "$HOME/.linuxbrew/bin/"
-        PATH="$HOME/.linuxbrew/bin:$HOME/.linuxbrew/sbin:$PATH"
-        ln -s "$PWD" "$HOME/.linuxbrew/Homebrew/Library/Taps/homebrew/homebrew-portable-ruby"
+        set -e
         docker build -f docker/Dockerfile.x86_64 -t homebrew-portable-x86_64 .
-        docker run homebrew-portable-x86_64 brew portable-package portable-ruby
+        # TODO: need to do something like:
+        # docker cp "$PWD" $(docker container ls -lq):"$HOME/.linuxbrew/Homebrew/Library/Taps/homebrew/homebrew-portable-ruby"
+        # to actually test the correct Git version in this repo
+        # docker run homebrew-portable-x86_64 brew portable-package portable-ruby
       displayName: Tests

--- a/cmd/brew-portable-package.rb
+++ b/cmd/brew-portable-package.rb
@@ -12,7 +12,6 @@
 #:    A new commit will then be generated unless `--no-commit` is passed.
 
 ENV["HOMEBREW_DEVELOPER"] = "1"
-ENV["HOMEBREW_PREFER_64_BIT"] = "1"
 
 include FileUtils
 

--- a/docker/Dockerfile.arm
+++ b/docker/Dockerfile.arm
@@ -14,15 +14,13 @@ USER linuxbrew
 WORKDIR /home/linuxbrew
 ENV PATH=/home/linuxbrew/.linuxbrew/bin:/home/linuxbrew/.linuxbrew/sbin:$PATH \
     HOMEBREW_BUILD_BOTTLE=1 \
-    HOMEBREW_BUILD_FROM_SOURCE=1 \
     HOMEBREW_FORCE_VENDOR_RUBY=1 \
     HOMEBREW_NO_ANALYTICS=1 \
     HOMEBREW_NO_AUTO_UPDATE=1
 
 RUN git clone --depth=1 https://github.com/Linuxbrew/brew /home/linuxbrew/.linuxbrew && \
     brew analytics off && \
-    brew tap Homebrew/core && \
-    brew tap Homebrew/portable-ruby
+    brew tap Homebrew/core
 
 ENV HOMEBREW_DEVELOPER=1
 

--- a/docker/Dockerfile.x86_64
+++ b/docker/Dockerfile.x86_64
@@ -14,15 +14,13 @@ USER linuxbrew
 WORKDIR /home/linuxbrew
 ENV PATH=/home/linuxbrew/.linuxbrew/bin:/home/linuxbrew/.linuxbrew/sbin:$PATH \
     HOMEBREW_BUILD_BOTTLE=1 \
-    HOMEBREW_BUILD_FROM_SOURCE=1 \
     HOMEBREW_FORCE_VENDOR_RUBY=1 \
     HOMEBREW_NO_ANALYTICS=1 \
     HOMEBREW_NO_AUTO_UPDATE=1
 
 RUN git clone --depth=1 https://github.com/Linuxbrew/brew /home/linuxbrew/.linuxbrew && \
     brew analytics off && \
-    brew tap Homebrew/core && \
-    brew tap Homebrew/portable-ruby
+    brew tap Homebrew/core
 
 ENV HOMEBREW_DEVELOPER=1
 


### PR DESCRIPTION
This will be used to build a new Portable Ruby for Homebrew 2.0.0 on Mavericks.

Should not be merged until Homebrew 2.0.0 will be released imminently.