### PR TITLE
portable-ruby 2.6.0

### DIFF
--- a/Formula/portable-openssl.rb
+++ b/Formula/portable-openssl.rb
@@ -3,11 +3,10 @@ require File.expand_path("../Abstract/portable-formula", __dir__)
 class PortableOpenssl < PortableFormula
   desc "SSL/TLS cryptography library"
   homepage "https://openssl.org/"
-  url "https://www.openssl.org/source/openssl-1.0.2q.tar.gz"
-  mirror "https://dl.bintray.com/homebrew/mirror/openssl-1.0.2q.tar.gz"
-  mirror "https://www.mirrorservice.org/sites/ftp.openssl.org/source/openssl-1.0.2q.tar.gz"
-  mirror "http://artfiles.org/openssl.org/source/openssl-1.0.2q.tar.gz"
-  sha256 "5744cfcbcec2b1b48629f7354203bc1e5e9b5466998bbccc5b5fcde3b18eb684"
+  url "https://www.openssl.org/source/openssl-1.0.2t.tar.gz"
+  mirror "https://dl.bintray.com/homebrew/mirror/openssl-1.0.2t.tar.gz"
+  mirror "https://www.mirrorservice.org/sites/ftp.openssl.org/source/openssl-1.0.2t.tar.gz"
+  sha256 "14cb464efe7ac6b54799b34456bd69558a749a4931ecfd9cf9f71d7881cac7bc"
 
   depends_on "makedepend" => :build
   depends_on "portable-zlib" => :build if OS.linux?

--- a/Formula/portable-ruby.rb
+++ b/Formula/portable-ruby.rb
@@ -10,8 +10,8 @@ class PortableRuby < PortableFormula
 
   bottle do
     cellar :any_skip_relocation
-    sha256 "539ae571968fc74d4ec3a839cb33edc5786c219a5e6ae7fb6a09ec5fc1b04e4e" => :mavericks
-    sha256 "9df214085a0e566a580eea3dd9eab14a2a94930ff74fbf97fb1284e905c8921d" => :x86_64_linux
+    sha256 "ab81211a2052ccaa6d050741c433b728d0641523d8742eef23a5b450811e5104" => :mavericks
+    sha256 "43395f680846bd2c5bf540bd5f0b8b7cf154a3b6d2802373eaabf7044baf91d2" => :x86_64_linux
   end
 
   depends_on "makedepend" => :build

--- a/Formula/portable-ruby.rb
+++ b/Formula/portable-ruby.rb
@@ -3,10 +3,10 @@ require File.expand_path("../Abstract/portable-formula", __dir__)
 class PortableRuby < PortableFormula
   desc "Powerful, clean, object-oriented scripting language"
   homepage "https://www.ruby-lang.org/"
-  # This is the version shipped in macOS 10.13.6.
-  url "https://cache.ruby-lang.org/pub/ruby/2.3/ruby-2.3.7.tar.bz2"
-  mirror "http://cache.ruby-lang.org/pub/ruby/2.3/ruby-2.3.7.tar.bz2"
-  sha256 "18b12fafaf37d5f6c7139c1b445355aec76baa625a40300598a6c8597fc04d8e"
+  # This is the version shipped in macOS 10.15.
+  url "https://cache.ruby-lang.org/pub/ruby/2.6/ruby-2.6.3.tar.bz2"
+  mirror "http://cache.ruby-lang.org/pub/ruby/2.6/ruby-2.6.3.tar.bz2"
+  sha256 "dd638bf42059182c1d04af0d5577131d4ce70b79105231c4cc0a60de77b14f2e"
 
   bottle do
     cellar :any_skip_relocation
@@ -104,7 +104,6 @@ class PortableRuby < PortableFormula
     assert_match "200",
       shell_output("#{ruby} -ropen-uri -e 'open(\"https://google.com\") { |f| puts f.status.first }'").strip
     system testpath/"bin/gem", "environment"
-    system testpath/"bin/gem", "install", "bundler"
     system testpath/"bin/bundle", "init"
     # install gem with native components
     system testpath/"bin/gem", "install", "byebug"


### PR DESCRIPTION
Ruby 2.6.0 is currently shipped in the macOS 10.15 betas. That might be subject to change.