### PR TITLE
Add linux/ppc64le build

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -54,6 +54,7 @@ jobs:
           - { name: x86_64, platform: linux/amd64, build_img: 'debian/eol:wheezy' }
           - { name: arm32v6, platform: linux/arm/v6, build_img: 'resin/rpi-raspbian:wheezy' }
           - { name: arm64v8, platform: linux/arm64/v8, build_img: 'debian/eol:jessie' }
+          - { name: ppc64le, platform: linux/ppc64le, build_img: 'debian/eol:jessie' }
     steps:
     - name: Set up Git repository
       uses: actions/checkout@master


### PR DESCRIPTION
👋 Hi team

Recently I have had opportunities to own and play with an POWER9 system at home. Having been a user of brew on Mac, I would love to see Linux ppc64le support homebrew fully.

This PR is my first attempt to make GitHub action to build ruby binary for linux/ppc64le.

The build failed with following error:

```
Cloning into '/home/linuxbrew/.linuxbrew/Homebrew'...
Cloning into '/home/linuxbrew/.linuxbrew/Homebrew/Library/Taps/homebrew/homebrew-core'...
Error: Cannot find a vendored version of ruby for your ppc64le
processor on Linuxbrew!
Error: Failed to install vendor Ruby.
```

It's seems to me `brew` is trying to [use a bottled portable ruby version](https://github.com/Homebrew/brew/blob/93c231cde5dd40956070e843ea92ea32667ba757/Library/Homebrew/cmd/vendor-install.sh#L27-L41). So I am wondering how those bottled were built and uploaded there in the first place?
