### PR TITLE
Updated dependencies

### DIFF
--- a/Formula/portable-libyaml.rb
+++ b/Formula/portable-libyaml.rb
@@ -3,8 +3,8 @@ require File.expand_path("../Abstract/portable-formula", __dir__)
 class PortableLibyaml < PortableFormula
   desc "YAML Parser"
   homepage "https://github.com/yaml/libyaml"
-  url "https://github.com/yaml/libyaml/archive/dist-0.2.2.tar.gz"
-  sha256 "689ef3ebdecfa81f3789ccd2481acc81fc0f22f3f5c947eed95c4c0802e356b8"
+  url "https://github.com/yaml/libyaml/releases/download/0.2.5/yaml-0.2.5.tar.gz"
+  sha256 "c642ae9b75fee120b2d96c712538bd2cf283228d2337df2cf2988e3c02678ef4"
 
   def install
     system "./configure", "--disable-dependency-tracking",

--- a/Formula/portable-ncurses.rb
+++ b/Formula/portable-ncurses.rb
@@ -3,9 +3,9 @@ require File.expand_path("../Abstract/portable-formula", __dir__)
 class PortableNcurses < PortableFormula
   desc "Text-based UI library"
   homepage "https://www.gnu.org/s/ncurses/"
-  url "https://ftp.gnu.org/gnu/ncurses/ncurses-6.1.tar.gz"
-  mirror "https://ftpmirror.gnu.org/ncurses/ncurses-6.1.tar.gz"
-  sha256 "aa057eeeb4a14d470101eff4597d5833dcef5965331be3528c08d99cebaa0d17"
+  url "https://ftp.gnu.org/gnu/ncurses/ncurses-6.2.tar.gz"
+  mirror "https://ftpmirror.gnu.org/ncurses/ncurses-6.2.tar.gz"
+  sha256 "30306e0c76e0f9f1f0de987cf1c82a5c21e1ce6568b9227f7da5b71cbea86c9d"
 
   depends_on "pkg-config" => :build
 
@@ -28,15 +28,12 @@ class PortableNcurses < PortableFormula
     major = version.to_s.split(".")[0]
 
     %w[form menu ncurses panel].each do |name|
-      lib.install_symlink "lib#{name}w.#{major}.dylib" => "lib#{name}.dylib"
-      lib.install_symlink "lib#{name}w.#{major}.dylib" => "lib#{name}.#{major}.dylib"
       lib.install_symlink "lib#{name}w.a" => "lib#{name}.a"
       lib.install_symlink "lib#{name}w_g.a" => "lib#{name}_g.a"
     end
 
     lib.install_symlink "libncurses++w.a" => "libncurses++.a"
     lib.install_symlink "libncurses.a" => "libcurses.a"
-    lib.install_symlink "libncurses.dylib" => "libcurses.dylib"
 
     (lib/"pkgconfig").install_symlink "ncursesw.pc" => "ncurses.pc"
 

--- a/Formula/portable-openssl.rb
+++ b/Formula/portable-openssl.rb
@@ -3,18 +3,15 @@ require File.expand_path("../Abstract/portable-formula", __dir__)
 class PortableOpenssl < PortableFormula
   desc "SSL/TLS cryptography library"
   homepage "https://openssl.org/"
-  url "https://www.openssl.org/source/openssl-1.0.2t.tar.gz"
-  mirror "https://dl.bintray.com/homebrew/mirror/openssl-1.0.2t.tar.gz"
-  mirror "https://www.mirrorservice.org/sites/ftp.openssl.org/source/openssl-1.0.2t.tar.gz"
-  sha256 "14cb464efe7ac6b54799b34456bd69558a749a4931ecfd9cf9f71d7881cac7bc"
-
-  depends_on "makedepend" => :build
-  depends_on "portable-zlib" => :build if OS.linux?
+  url "https://www.openssl.org/source/openssl-1.1.1g.tar.gz"
+  mirror "https://dl.bintray.com/homebrew/mirror/openssl-1.1.1g.tar.gz"
+  mirror "https://www.mirrorservice.org/sites/ftp.openssl.org/source/openssl-1.1.1g.tar.gz"
+  sha256 "ddb04774f1e32f0c49751e21b67216ac87852ceb056b75209af2443400636d46"
 
   resource "cacert" do
     # http://curl.haxx.se/docs/caextract.html
-    url "https://curl.haxx.se/ca/cacert-2019-08-28.pem"
-    sha256 "38b6230aa4bee062cd34ee0ff6da173250899642b1937fc130896290b6bd91e3"
+    url "https://curl.haxx.se/ca/cacert-2020-01-01.pem"
+    sha256 "adf770dfd574a0d6026bfaa270cb6879b063957177a991d453ff1d302c02081f"
   end
 
   def openssldir
@@ -47,48 +44,25 @@ class PortableOpenssl < PortableFormula
     args = %W[
       --prefix=#{prefix}
       --openssldir=#{openssldir}
-      no-ssl2
-      no-ssl3
       no-shared
-      enable-cms
     ]
-
-    if OS.mac?
-      args << "zlib-dynamic"
-    else
-      args << "-L#{Formula["portable-zlib"].opt_prefix/"lib"}"
-      args << "zlib"
-    end
 
     args
   end
 
   def install
-    # Load zlib from an explicit path instead of relying on dyld's fallback
-    # path, which is empty in a SIP context. This patch will be unnecessary
-    # when we begin building openssl with no-comp to disable TLS compression.
-    # https://langui.sh/2015/11/27/sip-and-dlopen
-    if OS.mac?
-      inreplace "crypto/comp/c_zlib.c",
-                'zlib_dso = DSO_load(NULL, "z", NULL, 0);',
-                'zlib_dso = DSO_load(NULL, "/usr/lib/libz.dylib", NULL, DSO_FLAG_NO_NAME_TRANSLATION);'
-    end
-
     ENV.deparallelize
     system "perl", "./Configure", *(configure_args + arch_args)
-    system "make", "depend"
     system "make"
     system "make", "test"
 
     system "make", "install", "MANDIR=#{man}"
     rm_rf man
 
-    if OS.linux?
-      # Since we build openssl which statically links to zlib on Linux,
-      # any program links to the openssl will have to link to zlib as well.
-      inreplace Dir["#{lib}/pkgconfig/lib*.pc"],
-        /(Libs: .*)/, "\\1 -L#{Formula["portable-zlib"].opt_prefix/"lib"} -lz"
-    end
+    # Ruby doesn't support passing --static to pkg-config.
+    # Unfortunately, this means we need to modify the OpenSSL pc file.
+    # This is a Ruby bug - not an OpenSSL one.
+    inreplace lib/"pkgconfig/libcrypto.pc", "\nLibs.private:", ""
 
     cacert = resource("cacert")
     filename = Pathname.new(cacert.url).basename
@@ -96,8 +70,12 @@ class PortableOpenssl < PortableFormula
   end
 
   test do
-    cp_r Dir["#{prefix}/*"], testpath
-    input = "x\x9CK\xCB\xCF\a\x00\x02\x82\x01E"
-    assert_equal "foo", pipe_output("#{testpath}/bin/openssl zlib -d", input)
+    (testpath/"testfile.txt").write("This is a test file")
+    expected_checksum = "e2d0fe1585a63ec6009c8016ff8dda8b17719a637405a4e23c0ff81339148249"
+    system bin/"openssl", "dgst", "-sha256", "-out", "checksum.txt", "testfile.txt"
+    open("checksum.txt") do |f|
+      checksum = f.read(100).split("=").last.strip
+      assert_equal checksum, expected_checksum
+    end
   end
 end

--- a/Formula/portable-readline.rb
+++ b/Formula/portable-readline.rb
@@ -5,11 +5,14 @@ class PortableReadline < PortableFormula
   homepage "https://tiswww.case.edu/php/chet/readline/rltop.html"
   url "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz"
   mirror "https://ftp.gnu.org/gnu/readline/readline-8.0.tar.gz"
-  version "8.0.1"
+  version "8.0.4"
   sha256 "e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461"
 
   %w[
     001 d8e5e98933cf5756f862243c0601cb69d3667bb33f2c7b751fe4e40b2c3fd069
+    002 36b0febff1e560091ae7476026921f31b6d1dd4c918dcb7b741aa2dad1aec8f7
+    003 94ddb2210b71eb5389c7756865d60e343666dfb722c85892f8226b26bb3eeaef
+    004 b1aa3d2a40eee2dea9708229740742e649c32bb8db13535ea78f8ac15377394c
   ].each_slice(2) do |p, checksum|
     patch :p0 do
       url "https://ftp.gnu.org/gnu/readline/readline-8.0-patches/readline80-#{p}"
@@ -26,9 +29,7 @@ class PortableReadline < PortableFormula
                           "--enable-static",
                           "--disable-shared",
                           ("--with-curses" if OS.linux?)
-    args = []
-    args << "SHLIB_LIBS=-lcurses" if OS.linux?
-    system "make", "install", *args
+    system "make", "install"
   end
 
   test do

--- a/Formula/portable-ruby.rb
+++ b/Formula/portable-ruby.rb
@@ -14,7 +14,6 @@ class PortableRuby < PortableFormula
     sha256 "e8c9b6d3dc5f40844e07b4b694897b8b7cb5a7dab1013b3b8712a22868f98c98" => :x86_64_linux
   end
 
-  depends_on "makedepend" => :build
   depends_on "pkg-config" => :build
   depends_on "portable-readline" => :build
   depends_on "portable-libyaml" => :build


### PR DESCRIPTION
* portable-libyaml 0.2.2 -> 0.2.5
* portable-ncurses 6.1 -> 6.2
  - Also removed `dylib` symlinks which did nothing as we don't build dynamic libraries.
* portable-openssl 1.0.2t -> 1.1.1g
  - 1.1.x no longer compiles zlib by default for security reasons (CRIME vulnerability). I've switched the formula to respect that.
  - Also updated Curl cert bundle to 2020-01-01.
  - Added a pkg-config hack to make Ruby link with OpenSSL correctly. Ruby doesn't appear to properly support statically linking OpenSSL sadly, hence the need for the hack.
* portable-readline 8.0.1 -> 8.0.4
  - Removed redundant `SHLIB_LIBS` as it is for shared libraries.