### PR TITLE
portable-ruby: bump revision for Linux rebuild

### DIFF
--- a/Formula/portable-ruby.rb
+++ b/Formula/portable-ruby.rb
@@ -7,7 +7,7 @@ class PortableRuby < PortableFormula
   url "https://cache.ruby-lang.org/pub/ruby/2.6/ruby-2.6.3.tar.bz2"
   mirror "http://cache.ruby-lang.org/pub/ruby/2.6/ruby-2.6.3.tar.bz2"
   sha256 "dd638bf42059182c1d04af0d5577131d4ce70b79105231c4cc0a60de77b14f2e"
-  revision 1
+  revision 2
 
   bottle do
     cellar :any_skip_relocation

--- a/Formula/portable-ruby.rb
+++ b/Formula/portable-ruby.rb
@@ -11,8 +11,8 @@ class PortableRuby < PortableFormula
 
   bottle do
     cellar :any_skip_relocation
-    sha256 "be48eade040e13e0e572300ba59cf43d5750f53a4f35d2051966a0194e3c0ab2" => :yosemite
-    sha256 "f5731ca80497c31ab1171ece4102e2104d9b6cd31aa7b35926e80829d4b0ce29" => :x86_64_linux
+    sha256 "b065e5e3783954f3e65d8d3a6377ca51649bfcfa21b356b0dd70490f74c6bd86" => :yosemite
+    sha256 "97e639a64dcec285392b53ad804b5334c324f1d2a8bdc2b5087b8bf8051e332f" => :x86_64_linux
   end
 
   depends_on "pkg-config" => :build

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Just `brew install homebrew/portable-ruby/<formula>`.
 
 ### macOS
 
-Run `brew portable-package ruby` inside an OS X 10.9 VM (so it is compatible with all working Homebrew macOS versions).
+Run `brew portable-package ruby` inside an OS X 10.10 VM (so it is compatible with all working Homebrew macOS versions).
 
 ### Linux
 


### PR DESCRIPTION
This includes newly-built bottles which should resolve #104 on Linux. The macOS version contains no changes, but was rebuilt so that we can bump the required Ruby revision to `2.6.3_2`.