### PR TITLE
cmd/portable-package: fix for Homebrew.args changes 

### DIFF
--- a/cmd/portable-package.rb
+++ b/cmd/portable-package.rb
@@ -28,13 +28,13 @@ module Homebrew
   end
 
   def portable_package
-    portable_package_args.parse
+    args = portable_package_args.parse
 
-    raise UsageError, "--no-commit requires --write!" if !Homebrew.args.write? && Homebrew.args.no_commit?
+    raise UsageError, "--no-commit requires --write!" if !args.write? && args.no_commit?
 
     ENV["HOMEBREW_DEVELOPER"] = "1"
 
-    Homebrew.args.named.each do |name|
+    args.named.each do |name|
       name = "portable-#{name}" unless name.start_with? "portable-"
       begin
         deps = Utils.popen_read("brew", "deps", "-n", "--include-build", name).split("\n")
@@ -43,17 +43,17 @@ module Homebrew
         safe_system "brew", "install", "--build-bottle", *deps if OS.linux?
 
         safe_system "brew", "install", "--build-bottle", name
-        unless Homebrew.args.no_uninstall_deps?
+        unless args.no_uninstall_deps?
           safe_system "brew", "uninstall", "--force", "--ignore-dependencies", *deps
         end
         safe_system "brew", "test", name
         puts "Linkage information:"
         safe_system "brew", "linkage", name
         bottle_args = %w[--skip-relocation]
-        bottle_args << "--no-rebuild" if Homebrew.args.no_rebuild?
-        bottle_args << "--keep-old" if Homebrew.args.keep_old?
-        bottle_args << "--write" if Homebrew.args.write?
-        bottle_args << "--no-commit" if Homebrew.args.no_commit?
+        bottle_args << "--no-rebuild" if args.no_rebuild?
+        bottle_args << "--keep-old" if args.keep_old?
+        bottle_args << "--write" if args.write?
+        bottle_args << "--no-commit" if args.no_commit?
         safe_system "brew", "bottle", *bottle_args, name
         Pathname.glob("*.bottle*.tar.gz") do |bottle_filename|
           bottle_file = bottle_filename.realpath

--- a/cmd/portable-package.rb
+++ b/cmd/portable-package.rb
@@ -37,7 +37,7 @@ module Homebrew
     args.named.each do |name|
       name = "portable-#{name}" unless name.start_with? "portable-"
       begin
-        deps = Utils.popen_read("brew", "deps", "-n", "--include-build", name).split("\n")
+        deps = Utils.safe_popen_read("brew", "deps", "-n", "--include-build", name).split("\n")
 
         # Avoid installing glibc. Bottles depend on glibc.
         safe_system "brew", "install", "--build-bottle", *deps if OS.linux?


### PR DESCRIPTION
Broke after Homebrew/brew#8144.

Also use `safe_popen_read`.