### PR TITLE
portable-ruby: patch to set correct arch on Apple Silicon

### DIFF
--- a/Formula/portable-ruby.rb
+++ b/Formula/portable-ruby.rb
@@ -64,6 +64,10 @@ class PortableRuby < PortableFormula
 
     args << "--with-opt-dir=#{paths.join(":")}"
 
+    # see: https://github.com/ruby/ruby/pull/3272
+    # needed to set correct arch on Apple Silicon as part of RUBY_PLATFORM
+    inreplace "configure", "\"processor-name=powerpc64\"\n#endif",
+        "\"processor-name=powerpc64\"\n#endif\n#ifdef __arm64__\n\"processor-name=arm64\"\n#endif"
     system "./configure", *args
     system "make"
     system "make", "install"


### PR DESCRIPTION
Without this patch, RUBY_PLATFORM returns just `-darwin20` instead of `arm64-darwin20`, which causes issues in `hardware.rb` in brew:

https://github.com/Homebrew/brew/blob/095798be405be47429877f9d92f416153f86e147/Library/Homebrew/hardware.rb#L87-L93
https://github.com/Homebrew/brew/blob/095798be405be47429877f9d92f416153f86e147/Library/Homebrew/hardware.rb#L109-L114

This is included within the generated `configure` script in ruby 2.7.2, but not in 2.7.1, and not in any 2.6.x releases.