### PR TITLE
More GitHub Packages improvements

### DIFF
--- a/Formula/portable-ruby.rb
+++ b/Formula/portable-ruby.rb
@@ -10,7 +10,8 @@ class PortableRuby < PortableFormula
   revision 2
 
   bottle do
-    sha256 cellar: :any_skip_relocation, yosemite: "b065e5e3783954f3e65d8d3a6377ca51649bfcfa21b356b0dd70490f74c6bd86"
+    root_url "https://ghcr.io/v2/homebrew/portable-ruby"
+    sha256 cellar: :any_skip_relocation, yosemite:     "b065e5e3783954f3e65d8d3a6377ca51649bfcfa21b356b0dd70490f74c6bd86"
     sha256 cellar: :any_skip_relocation, x86_64_linux: "97e639a64dcec285392b53ad804b5334c324f1d2a8bdc2b5087b8bf8051e332f"
   end
 

--- a/README.md
+++ b/README.md
@@ -25,6 +25,22 @@ docker run --name=homebrew-portable-ruby -w /bottle homebrew-portable brew porta
 docker cp homebrew-portable-ruby:/bottle .
 ```
 
+### Upload
+
+Copy the bottle `bottle*.tar.gz` files into a directory on your local machine.
+
+If you have the `bottle*.json` files: copy them too. If not, generate them with:
+
+```sh
+brew bottle *.tar.gz --json --root-url=https://ghcr.io/v2/homebrew/portable-ruby
+```
+
+Upload these files to GitHub Packages with:
+
+```sh
+brew pr-upload --root-url=https://ghcr.io/v2/homebrew/portable-ruby
+```
+
 ## Current Status
 
 Used in production for Homebrew/brew.


### PR DESCRIPTION
- Add the `root_url` as it's needed for now to be able to download this (until we don't assume taps are using Bintray).
- Indent `yosemite` hash correctly.
- Add documentation for how to upload bottles.