### PR TITLE
Dependency updates

### DIFF
--- a/Formula/portable-libyaml.rb
+++ b/Formula/portable-libyaml.rb
@@ -5,6 +5,7 @@ class PortableLibyaml < PortableFormula
   homepage "https://github.com/yaml/libyaml"
   url "https://github.com/yaml/libyaml/releases/download/0.2.5/yaml-0.2.5.tar.gz"
   sha256 "c642ae9b75fee120b2d96c712538bd2cf283228d2337df2cf2988e3c02678ef4"
+  license "MIT"
 
   def install
     system "./configure", "--disable-dependency-tracking",

--- a/Formula/portable-ncurses.rb
+++ b/Formula/portable-ncurses.rb
@@ -6,6 +6,7 @@ class PortableNcurses < PortableFormula
   url "https://ftp.gnu.org/gnu/ncurses/ncurses-6.2.tar.gz"
   mirror "https://ftpmirror.gnu.org/ncurses/ncurses-6.2.tar.gz"
   sha256 "30306e0c76e0f9f1f0de987cf1c82a5c21e1ce6568b9227f7da5b71cbea86c9d"
+  license "MIT"
 
   depends_on "pkg-config" => :build
 
@@ -19,7 +20,8 @@ class PortableNcurses < PortableFormula
                           "--enable-sigwinch",
                           "--enable-symlinks",
                           "--enable-widec",
-                          "--with-gpm=no"
+                          "--with-gpm=no",
+                          "--without-ada"
     system "make", "install"
     make_libncurses_symlinks
   end

--- a/Formula/portable-readline.rb
+++ b/Formula/portable-readline.rb
@@ -3,20 +3,18 @@ require File.expand_path("../Abstract/portable-formula", __dir__)
 class PortableReadline < PortableFormula
   desc "Library for command-line editing"
   homepage "https://tiswww.case.edu/php/chet/readline/rltop.html"
-  url "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz"
-  mirror "https://ftp.gnu.org/gnu/readline/readline-8.0.tar.gz"
-  version "8.0.4"
-  sha256 "e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461"
+  url "https://ftp.gnu.org/gnu/readline/readline-8.1.tar.gz"
+  mirror "https://ftpmirror.gnu.org/readline/readline-8.1.tar.gz"
+  version "8.1.1"
+  sha256 "f8ceb4ee131e3232226a17f51b164afc46cd0b9e6cef344be87c65962cb82b02"
+  license "GPL-3.0-or-later"
 
   %w[
-    001 d8e5e98933cf5756f862243c0601cb69d3667bb33f2c7b751fe4e40b2c3fd069
-    002 36b0febff1e560091ae7476026921f31b6d1dd4c918dcb7b741aa2dad1aec8f7
-    003 94ddb2210b71eb5389c7756865d60e343666dfb722c85892f8226b26bb3eeaef
-    004 b1aa3d2a40eee2dea9708229740742e649c32bb8db13535ea78f8ac15377394c
+    001 682a465a68633650565c43d59f0b8cdf149c13a874682d3c20cb4af6709b9144
   ].each_slice(2) do |p, checksum|
     patch :p0 do
-      url "https://ftp.gnu.org/gnu/readline/readline-8.0-patches/readline80-#{p}"
-      mirror "https://ftpmirror.gnu.org/readline/readline-8.0-patches/readline80-#{p}"
+      url "https://ftp.gnu.org/gnu/readline/readline-8.1-patches/readline81-#{p}"
+      mirror "https://ftpmirror.gnu.org/readline/readline-8.1-patches/readline81-#{p}"
       sha256 checksum
     end
   end
@@ -25,7 +23,6 @@ class PortableReadline < PortableFormula
 
   def install
     system "./configure", "--prefix=#{prefix}",
-                          "--enable-multibyte",
                           "--enable-static",
                           "--disable-shared",
                           ("--with-curses" if OS.linux?)

--- a/Formula/portable-zlib.rb
+++ b/Formula/portable-zlib.rb
@@ -2,14 +2,15 @@ require File.expand_path("../Abstract/portable-formula", __dir__)
 
 class PortableZlib < PortableFormula
   desc "General-purpose lossless data-compression library"
-  homepage "http://www.zlib.net/"
-  url "http://zlib.net/zlib-1.2.11.tar.gz"
+  homepage "https://www.zlib.net/"
+  url "https://zlib.net/zlib-1.2.11.tar.gz"
   mirror "https://downloads.sourceforge.net/project/libpng/zlib/1.2.11/zlib-1.2.11.tar.gz"
   sha256 "c3e5e9fdd5004dcb542feda5ee4f0ff0744628baf8ed2dd5d66f8ca1197cb1a1"
+  license "Zlib"
 
-  # http://zlib.net/zlib_how.html
+  # https://zlib.net/zlib_how.html
   resource "test_artifact" do
-    url "http://zlib.net/zpipe.c"
+    url "https://zlib.net/zpipe.c"
     version "20051211"
     sha256 "68140a82582ede938159630bca0fb13a93b4bf1cb2e85b08943c26242cf8f3a6"
   end


### PR DESCRIPTION
Align some formulae with changes made in Homebrew/core (except where differences are intentional).

I've also disabled MD2 support in OpenSSL. This is a legacy protocol and we shouldn't be using this anyway, let alone explicitly enable it.