### PR TITLE
portable-openssl: update cacert

### DIFF
--- a/Formula/portable-openssl.rb
+++ b/Formula/portable-openssl.rb
@@ -10,9 +10,9 @@ class PortableOpenssl < PortableFormula
   license "OpenSSL"
 
   resource "cacert" do
-    # http://curl.se/docs/caextract.html
-    url "https://curl.se/ca/cacert-2021-07-05.pem"
-    sha256 "a3b534269c6974631db35f952e8d7c7dbf3d81ab329a232df575c2661de1214a"
+    # https://curl.se/docs/caextract.html
+    url "https://curl.se/ca/cacert-2021-09-30.pem"
+    sha256 "f524fc21859b776e18df01a87880efa198112214e13494275dbcbd9bcb71d976"
   end
 
   # Fix build on older macOS versions.


### PR DESCRIPTION
Update to 2021-09-30.