### PR TITLE
Bump x86_64 macOS build to use El Capitan

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -34,6 +34,12 @@ jobs:
         id: set-up-homebrew
         uses: Homebrew/actions/setup-homebrew@master
 
+      - run: brew test-bot --only-cleanup-before
+
+      - run: brew test-bot --only-setup
+
+      - run: brew test-bot --only-tap-syntax
+
       - name: Build Docker image
         if: runner.os == 'Linux'
         run: |
@@ -72,3 +78,9 @@ jobs:
             docker run --rm -v $(pwd):/data -e HOMEBREW_RUBY_PATH=/data/portable-ruby/bin/ruby \
               homebrew-portable-test /bin/bash -c "brew config"
           fi
+
+      - name: Post cleanup
+        if: always()
+        run: |
+          brew test-bot --only-cleanup-after
+          rm -rvf bottles portable-ruby

--- a/Abstract/portable-formula.rb
+++ b/Abstract/portable-formula.rb
@@ -6,7 +6,7 @@ module PortableFormulaMixin
       oldest_macos = if Hardware::CPU.arm?
         :big_sur
       else
-        :yosemite
+        :el_capitan
       end
       if OS::Mac.version > oldest_macos
         opoo <<~EOS

--- a/Formula/portable-libxcrypt.rb
+++ b/Formula/portable-libxcrypt.rb
@@ -11,7 +11,8 @@ class PortableLibxcrypt < PortableFormula
     # Compling util-xbzero.c crashes with "invalid argument to gimple call" on Wheezy's GCC 4.7.2.
     # Use the GCC 4.9 backport to avoid this.
     ENV["HOMEBREW_CC"] = "/usr/lib/gcc-4.9-backport/bin/gcc" if ENV["HOMEBREW_ON_DEBIAN7"].present?
-    system "./configure", *std_configure_args,
+    system "./configure", *portable_configure_args,
+                          *std_configure_args,
                           "--enable-static",
                           "--disable-shared",
                           "--disable-obsolete-api",

--- a/Formula/portable-libyaml.rb
+++ b/Formula/portable-libyaml.rb
@@ -8,7 +8,8 @@ class PortableLibyaml < PortableFormula
   license "MIT"
 
   def install
-    system "./configure", "--disable-dependency-tracking",
+    system "./configure", *portable_configure_args,
+                          "--disable-dependency-tracking",
                           "--prefix=#{prefix}",
                           "--enable-static",
                           "--disable-shared"

--- a/Formula/portable-ncurses.rb
+++ b/Formula/portable-ncurses.rb
@@ -17,7 +17,8 @@ class PortableNcurses < PortableFormula
     # Linux: configure: error: expected a pathname, not ""
     (lib/"pkgconfig").mkpath
 
-    system "./configure", "--disable-dependency-tracking",
+    system "./configure", *portable_configure_args,
+                          "--disable-dependency-tracking",
                           "--prefix=#{prefix}",
                           "--enable-static",
                           "--disable-shared",

--- a/Formula/portable-openssl.rb
+++ b/Formula/portable-openssl.rb
@@ -15,6 +15,18 @@ class PortableOpenssl < PortableFormula
     sha256 "1979e7fe618c51ed1c9df43bba92f977a0d3fe7497ffa2a5e80dfc559a1e5a29"
   end
 
+  # Fix failing test due to expired certificates.
+  # Remove with the next version (1.1.1p).
+  patch do
+    url "https://github.com/openssl/openssl/commit/73db5d82489b3ec09ccc772dfcee14fef0e8e908.patch?full_index=1"
+    sha256 "4b04ce0b7a3132c640bdc7726c7efaeb28572c5b8cdffcdc80fea700ded964e3"
+  end
+
+  patch do
+    url "https://github.com/openssl/openssl/commit/b7ce611887cfac633aacc052b2e71a7f195418b8.patch?full_index=1"
+    sha256 "6a81f4b2edb9ca3d56d897b4c85faac59fb488434dae6f0b5c525e9f96c879df"
+  end
+
   def openssldir
     libexec/"etc/openssl"
   end

--- a/Formula/portable-readline.rb
+++ b/Formula/portable-readline.rb
@@ -23,10 +23,13 @@ class PortableReadline < PortableFormula
   depends_on "portable-ncurses" => :build if OS.linux?
 
   def install
-    system "./configure", "--prefix=#{prefix}",
-                          "--enable-static",
-                          "--disable-shared",
-                          ("--with-curses" if OS.linux?)
+    args = portable_configure_args + %W[
+      --prefix=#{prefix}
+      --enable-static
+      --disable-shared
+    ]
+    args << "--with-curses" if OS.linux?
+    system "./configure", *args
     system "make", "install"
   end
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Just `brew install homebrew/portable-ruby/<formula>`.
 
 ### macOS
 
-Run `brew portable-package ruby` inside an OS X 10.10 VM (so it is compatible with all working Homebrew macOS versions).
+Run `brew portable-package ruby` inside an OS X 10.11 VM (so it is compatible with all working Homebrew macOS versions).
 
 ### Linux
 


### PR DESCRIPTION
Homebrew 3.5.0 is targetted to drop Yosemite support, so let's drop it here too.

I've set up a temporary CI node to test a 10.11 cross-compile on 10.13 (using 10.11 dev tools: Xcode 7.3.1). Very much an experimental setup but we'll see how it works.

CI changes will be dropped from the PR and I'll do it properly in a subsequent PR.