### PR TITLE
Remove bottle block

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,11 +62,6 @@ jobs:
       - name: Configure Git user
         uses: Homebrew/actions/git-user-config@master
 
-      - name: Set up commit signing
-        uses: Homebrew/actions/setup-commit-signing@master
-        with:
-          signing_key: ${{ secrets.BREWTESTBOT_GPG_SIGNING_SUBKEY }}
-
       - name: Setup directory
         run: mkdir bottles
 
@@ -79,21 +74,9 @@ jobs:
       - name: Upload to GitHub Packages
         working-directory: bottles
         env:
-          BREWTESTBOT_NAME_EMAIL: "BrewTestBot <1589480+BrewTestBot@users.noreply.github.com>"
-          HOMEBREW_GPG_PASSPHRASE: ${{ secrets.BREWTESTBOT_GPG_SIGNING_SUBKEY_PASSPHRASE }}
           HOMEBREW_GITHUB_PACKAGES_USER: ${{ github.actor }}
           HOMEBREW_GITHUB_PACKAGES_TOKEN: ${{ github.token }}
-        run: brew pr-upload --debug --committer="${BREWTESTBOT_NAME_EMAIL}" --root-url=https://ghcr.io/v2/${GITHUB_REPOSITORY_OWNER,,}/portable-ruby
-
-      - name: Push commits
-        uses: Homebrew/actions/git-try-push@master
-        with:
-          token: ${{ github.token }}
-          branch: ${{ github.ref_name }}
-        env:
-          GIT_COMMITTER_NAME: BrewTestBot
-          GIT_COMMITTER_EMAIL: 1589480+BrewTestBot@users.noreply.github.com
-          HOMEBREW_GPG_PASSPHRASE: ${{ secrets.BREWTESTBOT_GPG_SIGNING_SUBKEY_PASSPHRASE }}
+        run: brew pr-upload --debug --upload-only --root-url=https://ghcr.io/v2/${GITHUB_REPOSITORY_OWNER,,}/portable-ruby
 
       - name: Push tag
         env:

--- a/Formula/portable-ruby.rb
+++ b/Formula/portable-ruby.rb
@@ -9,13 +9,6 @@ class PortableRuby < PortableFormula
   license "Ruby"
   revision 1
 
-  bottle do
-    root_url "https://ghcr.io/v2/homebrew/portable-ruby"
-    sha256 cellar: :any_skip_relocation, arm64_big_sur: "f2d5cab5a4dd49e5b3de780a3cd0a1f61642fea247d1c25aa40cd43f1be290b5"
-    sha256 cellar: :any_skip_relocation, yosemite:      "0cb1cc7af109437fe0e020c9f3b7b95c3c709b140bde9f991ad2c1433496dd42"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "cd7fffb18ef9338baa670fc5e8fce99b0e3cc0f0fd7627bcbb56f3c8d54161d4"
-  end
-
   depends_on "pkg-config" => :build
   depends_on "portable-readline" => :build
   depends_on "portable-libyaml" => :build

--- a/README.md
+++ b/README.md
@@ -36,12 +36,10 @@ Copy the bottle `bottle*.tar.gz` and `bottle*.json` files into a directory on yo
 Upload these files to GitHub Packages with:
 
 ```sh
-brew pr-upload --root-url=https://ghcr.io/v2/homebrew/portable-ruby
+brew pr-upload --upload-only --root-url=https://ghcr.io/v2/homebrew/portable-ruby
 ```
 
-This will create a bottle commit. Open a PR and merge this into master.
-
-Once the commit is in master, create a new GitHub tag with:
+And to GitHub releases:
 
 ```sh
 brew pr-upload --upload-only --root-url=https://github.com/Homebrew/homebrew-portable-ruby/releases/download/$VERSION

--- a/cmd/portable-package.rb
+++ b/cmd/portable-package.rb
@@ -16,13 +16,8 @@ module Homebrew
       EOS
       switch "--no-uninstall-deps",
              description: "Don't uninstall all dependencies of portable formulae before testing."
-      switch "--no-rebuild",
-             description: "Remove `rebuild`."
-      switch "--keep-old",
-             description: "Attempt to keep `rebuild` at its original value."
       switch "-v", "--verbose",
              description: "Pass `--verbose` to `brew` commands."
-      conflicts "--no-rebuild", "--keep-old"
       named_args :formula, min: 1
     end
   end
@@ -55,9 +50,8 @@ module Homebrew
           --skip-relocation
           --root-url=https://ghcr.io/v2/homebrew/portable-ruby
           --json
+          --no-rebuild
         ]
-        bottle_args << "--no-rebuild" if args.no_rebuild?
-        bottle_args << "--keep-old" if args.keep_old?
         safe_system "brew", "bottle", *verbose, *bottle_args, name
         Pathname.glob("*.bottle*.tar.gz") do |bottle_filename|
           bottle_file = bottle_filename.realpath


### PR DESCRIPTION
It's not worth trying to manage bottle commits (which means turning off CI checks etc.) in the release workflow for what zero users are going to use.

This also reduces the number of secrets required to zero.