### PR TITLE
Rename SSL_CERT_FILE to avoid overriding system SSL cert file

### DIFF
--- a/Formula/portable-openssl.rb
+++ b/Formula/portable-openssl.rb
@@ -46,6 +46,11 @@ class PortableOpenssl < PortableFormula
   end
 
   def install
+    # OpenSSL is not fully portable and certificate paths are backed into the library.
+    # We therefore need to set the certificate path at runtime via an environment variable.
+    # We however don't want to touch _other_ OpenSSL usages, so we change the variable name to differ.
+    inreplace "include/internal/cryptlib.h", "\"SSL_CERT_FILE\"", "\"PORTABLE_RUBY_SSL_CERT_FILE\""
+
     system "perl", "./Configure", *(configure_args + arch_args)
     system "make"
     system "make", "test"

--- a/Formula/portable-ruby.rb
+++ b/Formula/portable-ruby.rb
@@ -105,7 +105,7 @@ class PortableRuby < PortableFormula
     cp openssl.libexec/"etc/openssl/cert.pem", libexec/"cert.pem"
     openssl_rb = lib/"ruby/#{abi_version}/openssl.rb"
     inreplace openssl_rb, "require 'openssl.so'", <<~EOS.chomp
-      ENV["SSL_CERT_FILE"] ||= File.expand_path("../../libexec/cert.pem", RbConfig.ruby)
+      ENV["PORTABLE_RUBY_SSL_CERT_FILE"] = ENV["SSL_CERT_FILE"] || File.expand_path("../../libexec/cert.pem", RbConfig.ruby)
       \\0
     EOS
   end


### PR DESCRIPTION
We set a default `SSL_CERT_FILE` because OpenSSL contains fixed paths baked in that cannot be avoided.

However setting this has the unintended effect of affecting _all_ OpenSSL usages (e.g. in curl) rather than just the one linked into our portable Ruby.

We need to set a `SSL_CERT_FILE` otherwise `open-uri` etc will break, so let's just rename the portable-openssl variable to something different.

https://github.com/Homebrew/brew/issues/14828