### PR TITLE
Dependency updates (2023-04-11)

### DIFF
--- a/Formula/portable-libedit.rb
+++ b/Formula/portable-libedit.rb
@@ -3,9 +3,9 @@ require File.expand_path("../Abstract/portable-formula", __dir__)
 class PortableLibedit < PortableFormula
   desc "BSD-style licensed readline alternative"
   homepage "https://thrysoee.dk/editline/"
-  url "https://thrysoee.dk/editline/libedit-20221009-3.1.tar.gz"
-  version "20221009-3.1"
-  sha256 "b7b135a5112ce4344c9ac3dff57cc057b2b0e1b912619a36cf1d13fce8e88626"
+  url "https://thrysoee.dk/editline/libedit-20221030-3.1.tar.gz"
+  version "20221030-3.1"
+  sha256 "f0925a5adf4b1bf116ee19766b7daa766917aec198747943b1c4edf67a4be2bb"
   license "BSD-3-Clause"
 
   on_linux do

--- a/Formula/portable-ncurses.rb
+++ b/Formula/portable-ncurses.rb
@@ -3,10 +3,10 @@ require File.expand_path("../Abstract/portable-formula", __dir__)
 class PortableNcurses < PortableFormula
   desc "Text-based UI library"
   homepage "https://invisible-island.net/ncurses/announce.html"
-  url "https://ftp.gnu.org/gnu/ncurses/ncurses-6.3.tar.gz"
-  mirror "https://invisible-mirror.net/archives/ncurses/ncurses-6.3.tar.gz"
-  mirror "https://ftpmirror.gnu.org/ncurses/ncurses-6.3.tar.gz"
-  sha256 "97fc51ac2b085d4cde31ef4d2c3122c21abc217e9090a43a30fc5ec21684e059"
+  url "https://ftp.gnu.org/gnu/ncurses/ncurses-6.4.tar.gz"
+  mirror "https://invisible-mirror.net/archives/ncurses/ncurses-6.4.tar.gz"
+  mirror "https://ftpmirror.gnu.org/ncurses/ncurses-6.4.tar.gz"
+  sha256 "6931283d9ac87c5073f30b6290c4c75f21632bb4fc3603ac8100812bed248159"
   license "MIT"
 
   depends_on "pkg-config" => :build

--- a/Formula/portable-openssl.rb
+++ b/Formula/portable-openssl.rb
@@ -3,16 +3,16 @@ require File.expand_path("../Abstract/portable-formula", __dir__)
 class PortableOpenssl < PortableFormula
   desc "SSL/TLS cryptography library"
   homepage "https://openssl.org/"
-  url "https://www.openssl.org/source/openssl-1.1.1q.tar.gz"
-  mirror "https://www.mirrorservice.org/sites/ftp.openssl.org/source/openssl-1.1.1q.tar.gz"
-  mirror "https://www.openssl.org/source/old/1.1.1/openssl-1.1.1q.tar.gz"
-  sha256 "d7939ce614029cdff0b6c20f0e2e5703158a489a72b2507b8bd51bf8c8fd10ca"
+  url "https://www.openssl.org/source/openssl-1.1.1t.tar.gz"
+  mirror "https://www.mirrorservice.org/sites/ftp.openssl.org/source/openssl-1.1.1t.tar.gz"
+  mirror "https://www.openssl.org/source/old/1.1.1/openssl-1.1.1t.tar.gz"
+  sha256 "8dee9b24bdb1dcbf0c3d1e9b02fb8f6bf22165e807f45adeb7c9677536859d3b"
   license "OpenSSL"
 
   resource "cacert" do
     # https://curl.se/docs/caextract.html
-    url "https://curl.se/ca/cacert-2022-10-11.pem"
-    sha256 "2cff03f9efdaf52626bd1b451d700605dc1ea000c5da56bd0fc59f8f43071040"
+    url "https://curl.se/ca/cacert-2023-01-10.pem"
+    sha256 "fb1ecd641d0a02c01bc9036d513cb658bbda62a75e246bedbc01764560a639f0"
   end
 
   def openssldir


### PR DESCRIPTION
* [portable-libedit 20221030-3.1](https://github.com/Homebrew/homebrew-portable-ruby/commit/d9d7471468e1bb185c4c801fcd0749de7210ccd0)
* [portable-ncurses 6.4](https://github.com/Homebrew/homebrew-portable-ruby/commit/c19a05453ba603498cb4f32191690aa8befc9fd7)
* [portable-openssl 1.1.1t](https://github.com/Homebrew/homebrew-portable-ruby/commit/4c68437628688a48d90a2316639ff966b20b9898) & bundled certificates