### PR TITLE
Ruby 3 working branch

### DIFF
--- a/Formula/portable-libffi.rb
+++ b/Formula/portable-libffi.rb
@@ -1,0 +1,65 @@
+require File.expand_path("../Abstract/portable-formula", __dir__)
+
+class PortableLibffi < PortableFormula
+  desc "Portable Foreign Function Interface library"
+  homepage "https://sourceware.org/libffi/"
+  url "https://github.com/libffi/libffi/releases/download/v3.4.4/libffi-3.4.4.tar.gz"
+  sha256 "d66c56ad259a82cf2a9dfc408b32bf5da52371500b84745f7fb8b645712df676"
+  license "MIT"
+
+  def install
+    system "./configure", *portable_configure_args,
+                          *std_configure_args,
+                          "--enable-static",
+                          "--disable-shared",
+                          "--disable-docs"
+    system "make", "install"
+  end
+
+  test do
+    (testpath/"closure.c").write <<~EOS
+      #include <stdio.h>
+      #include <ffi.h>
+      /* Acts like puts with the file given at time of enclosure. */
+      void puts_binding(ffi_cif *cif, unsigned int *ret, void* args[],
+                        FILE *stream)
+      {
+        *ret = fputs(*(char **)args[0], stream);
+      }
+      int main()
+      {
+        ffi_cif cif;
+        ffi_type *args[1];
+        ffi_closure *closure;
+        int (*bound_puts)(char *);
+        int rc;
+        /* Allocate closure and bound_puts */
+        closure = ffi_closure_alloc(sizeof(ffi_closure), &bound_puts);
+        if (closure)
+          {
+            /* Initialize the argument info vectors */
+            args[0] = &ffi_type_pointer;
+            /* Initialize the cif */
+            if (ffi_prep_cif(&cif, FFI_DEFAULT_ABI, 1,
+                             &ffi_type_uint, args) == FFI_OK)
+              {
+                /* Initialize the closure, setting stream to stdout */
+                if (ffi_prep_closure_loc(closure, &cif, puts_binding,
+                                         stdout, bound_puts) == FFI_OK)
+                  {
+                    rc = bound_puts("Hello World!");
+                    /* rc now holds the result of the call to fputs */
+                  }
+              }
+          }
+        /* Deallocate both closure, and bound_puts */
+        ffi_closure_free(closure);
+        return 0;
+      }
+    EOS
+
+    flags = ["-L#{lib}", "-lffi", "-I#{include}"]
+    system ENV.cc, "-o", "closure", "closure.c", *(flags + ENV.cflags.to_s.split)
+    system "./closure"
+  end
+end


### PR DESCRIPTION
Tests for Ruby 3.2.

What I plan for this branch:
* This will be rebased as necessary until all builds pass _and_ the "TEMP: workflow workarounds for ruby3 branch" commit is no longer required (i.e. `brew` itself supports handling of Ruby 3 gems).
* At that point, I'll make it a protected branch and we can make releases from that branch that we can use in `brew`.
* When Ruby 2.6 is killed (i.e. we are sure we will never need to make another Portable Ruby 2.6 release again), then this PR can be merged.

Don't really want to faff around with versioned formulae and adjusting all the workflows to build twice when branches work fine for this purpose, are simpler and make the diff easier to follow.