### PR TITLE
Resolve NoMethodError on brew install

### DIFF
--- a/Abstract/portable-formula.rb
+++ b/Abstract/portable-formula.rb
@@ -33,10 +33,12 @@ module PortableFormulaMixin
   def install
     if OS.mac?
       if OS::Mac.version > TARGET_MACOS
+        target_macos_humanized = TARGET_MACOS.to_s.tr("_", " ").split.map(&:capitalize).join(" ")
+
         opoo <<~EOS
           You are building portable formula on #{OS::Mac.version}.
           As result, formula won't be able to work on older macOS versions.
-          It's recommended to build this formula on macOS #{TARGET_MACOS.to_s.humanize.titleize}
+          It's recommended to build this formula on macOS #{target_macos_humanized}
           (the oldest version that can run Homebrew).
         EOS
       end


### PR DESCRIPTION
before:

```
 $ brew install homebrew/portable-ruby/portable-ruby
==> Fetching dependencies for homebrew/portable-ruby/portable-ruby: homebrew/portable-ruby/portable-libyaml and homebrew/portable-ruby/portable-openssl
==> Fetching homebrew/portable-ruby/portable-libyaml
==> Downloading https://github.com/yaml/libyaml/releases/download/0.2.5/yaml-0.2.5.tar.gz
==> Downloading from https://objects.githubusercontent.com/github-production-release-asset-2e65be/2699072/83e7a200-a461-11ea-9884-f4fc06ba83bc?X-Amz-Algo
################################################################################################################################################## 100.0%
==> Fetching homebrew/portable-ruby/portable-openssl
==> Downloading https://curl.se/ca/cacert-2023-08-22.pem
################################################################################################################################################## 100.0%
==> Downloading https://www.openssl.org/source/openssl-1.1.1w.tar.gz
################################################################################################################################################## 100.0%
==> Fetching homebrew/portable-ruby/portable-ruby
==> Downloading https://cache.ruby-lang.org/pub/ruby/2.6/ruby-2.6.10.tar.xz
################################################################################################################################################## 100.0%
==> Installing portable-ruby from homebrew/portable-ruby
==> Installing dependencies for homebrew/portable-ruby/portable-ruby: homebrew/portable-ruby/portable-libyaml and homebrew/portable-ruby/portable-openssl
==> Installing homebrew/portable-ruby/portable-ruby dependency: homebrew/portable-ruby/portable-libyaml
Error: An exception occurred within a child process:
  NoMethodError: undefined method `humanize' for "big_sur":String
```

after:
```
 $ brew install homebrew/portable-ruby/portable-ruby
==> Downloading https://formulae.brew.sh/api/formula.jws.json

==> Fetching dependencies for homebrew/portable-ruby/portable-ruby: homebrew/portable-ruby/portable-libyaml and homebrew/portable-ruby/portable-openssl
==> Fetching homebrew/portable-ruby/portable-libyaml
==> Downloading https://github.com/yaml/libyaml/releases/download/0.2.5/yaml-0.2.5.tar.gz
Already downloaded: /Users/dug/Library/Caches/Homebrew/downloads/dc25902bf97807278d36e976dafb46da852c50025c8492c7d66eeee75a8aacf4--yaml-0.2.5.tar.gz
==> Fetching homebrew/portable-ruby/portable-openssl
==> Downloading https://curl.se/ca/cacert-2023-08-22.pem
Already downloaded: /Users/dug/Library/Caches/Homebrew/downloads/5189855c1bb1eb307e142401724978880a272b70d94939c3c91a51fc34568cc4--cacert-2023-08-22.pem
==> Downloading https://www.openssl.org/source/openssl-1.1.1w.tar.gz
Already downloaded: /Users/dug/Library/Caches/Homebrew/downloads/6300164b52319bb37dce9e31e2afc01b0daa2996027c1099d5ee5c520a06eb79--openssl-1.1.1w.tar.gz
==> Fetching homebrew/portable-ruby/portable-ruby
==> Downloading https://cache.ruby-lang.org/pub/ruby/2.6/ruby-2.6.10.tar.xz
Already downloaded: /Users/dug/Library/Caches/Homebrew/downloads/41a77b75a907d1f098a05fa8fbb8584d98ee230848263952c7078a0ea2fe5068--ruby-2.6.10.tar.xz
==> Installing portable-ruby from homebrew/portable-ruby
==> Installing dependencies for homebrew/portable-ruby/portable-ruby: homebrew/portable-ruby/portable-libyaml and homebrew/portable-ruby/portable-openssl
==> Installing homebrew/portable-ruby/portable-ruby dependency: homebrew/portable-ruby/portable-libyaml
Warning: You are building portable formula on 14.
As result, formula won't be able to work on older macOS versions.
It's recommended to build this formula on macOS Big Sur
(the oldest version that can run Homebrew).
==> ./configure --build=aarch64-apple-darwin23.0.0 --host=aarch64-apple-darwin20.1.0 --enable-static --disable-shared
==> make install
🍺  /opt/homebrew/Cellar/portable-libyaml/0.2.5: 8 files, 209.6KB, built in 17 seconds
==> Installing homebrew/portable-ruby/portable-ruby dependency: homebrew/portable-ruby/portable-openssl
Warning: You are building portable formula on 14.
As result, formula won't be able to work on older macOS versions.
It's recommended to build this formula on macOS Big Sur
(the oldest version that can run Homebrew).
==> perl ./Configure --prefix=/opt/homebrew/Cellar/portable-openssl/1.1.1w --openssldir=/opt/homebrew/Cellar/portable-openssl/1.1.1w/libexec/etc/openssl no-shared darwin64-arm64-cc enable-ec_nistp_64_gcc_128
==> make
==> make test
==> make install_sw
🍺  /opt/homebrew/Cellar/portable-openssl/1.1.1w: 119 files, 9.4MB, built in 1 minute 57 seconds
==> Installing homebrew/portable-ruby/portable-ruby
Warning: You are building portable formula on 14.
As result, formula won't be able to work on older macOS versions.
It's recommended to build this formula on macOS Big Sur
(the oldest version that can run Homebrew).
==> ./configure --build=aarch64-apple-darwin23.0.0 --host=aarch64-apple-darwin20.1.0 --enable-load-relative --with-static-linked-ext --with-out-ext=tk,sdbm,gdbm,dbm --without-gmp --enable-libedit --disable-insta
==> make RUN_OPTS=/private/tmp/portable-ruby-20230930-26428-o3vmog/ruby-2.6.10/tool/runruby.rb --extout=.ext
==> make install RUN_OPTS=/private/tmp/portable-ruby-20230930-26428-o3vmog/ruby-2.6.10/tool/runruby.rb --extout=.ext
==> Caveats
portable-ruby is keg-only, which means it was not symlinked into /opt/homebrew,
because portable formulae are keg-only.

If you need to have portable-ruby first in your PATH, run:
  echo 'export PATH="/opt/homebrew/opt/portable-ruby/bin:$PATH"' >> ~/.zshrc

For compilers to find portable-ruby you may need to set:
  export LDFLAGS="-L/opt/homebrew/opt/portable-ruby/lib"
  export CPPFLAGS="-I/opt/homebrew/opt/portable-ruby/include"

For pkg-config to find portable-ruby you may need to set:
  export PKG_CONFIG_PATH="/opt/homebrew/opt/portable-ruby/lib/pkgconfig"
==> Summary
🍺  /opt/homebrew/Cellar/portable-ruby/2.6.10_1: 1,393 files, 24.2MB, built in 1 minute 49 seconds
```

(I'm open to the suggestion that I have something misconfigured.)