### PR TITLE
workflows: various cleanups

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,14 +9,13 @@ permissions:
 env:
   HOMEBREW_DEVELOPER: 1
   HOMEBREW_NO_AUTO_UPDATE: 1
-  HOMEBREW_CHANGE_ARCH_TO_ARM: 1
 
 jobs:
   build:
     strategy:
       matrix:
         include:
-          - os: '10.11-cross-${{github.run_id}}-${{github.run_attempt}}'
+          - os: '10.11-cross-${{github.run_id}}'
           - os: '11-arm64'
           - os: 'ubuntu-latest'
             container:
@@ -30,11 +29,6 @@ jobs:
       run:
         working-directory: ${{matrix.workdir || github.workspace}}
     steps:
-      - name: Set environment variables
-        if: runner.os == 'macOS'
-        run: |
-          echo 'PATH=/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin' >> $GITHUB_ENV
-
       - name: Set up Homebrew
         uses: Homebrew/actions/setup-homebrew@master
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,8 +8,7 @@ env:
   HOMEBREW_NO_AUTO_UPDATE: 1
 
 permissions:
-  contents: write
-  packages: write
+  contents: read
 
 jobs:
   determine-tag:
@@ -47,6 +46,9 @@ jobs:
     runs-on: ubuntu-latest
     env:
       TAG: ${{ needs.determine-tag.outputs.tag }}
+    permissions:
+      contents: write
+      packages: write
     steps:
       - name: Set up Homebrew
         uses: Homebrew/actions/setup-homebrew@master
@@ -54,10 +56,10 @@ jobs:
           test-bot: false
 
       - name: Checkout branch
-        run: git checkout "${{ github.ref_name }}"
+        run: git checkout "${GITHUB_REF_NAME}"
 
       - name: Install gems
-        run: brew install-bundler-gems
+        run: brew install-bundler-gems --groups=pr_upload
 
       - name: Configure Git user
         uses: Homebrew/actions/git-user-config@master

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,9 +1,6 @@
 name: CI
 
 on:
-  push:
-    branches:
-      - master
   pull_request:
 
 permissions:
@@ -11,7 +8,7 @@ permissions:
 
 concurrency:
   group: "${{ github.ref }}"
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  cancel-in-progress: true
 
 jobs:
   tests:


### PR DESCRIPTION
* Remove CI on `master` push. This is a low volume repository so spending an extra 20-25 minutes is a waste of self-hosted resources when we don't allow direct pushes without a pull request. If there's a concern of two simultaneous PRs causing problems only when merged together, we can enable "Require branches to be up to date before merging", which will solve those concerns with minimal annoyance given the PR volume.
* Remove run attempt from ephemeral names as we don't need that anymore.
* Scope permissions slightly more tightly
* Minor cleanup of unused stuff