### PR TITLE
workflows/build: use new 11-arm64-cross runner

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
       matrix:
         include:
           - os: '10.11-cross-${{github.run_id}}'
-          - os: '11-arm64'
+          - os: '11-arm64-cross-${{github.run_id}}'
           - os: 'ubuntu-latest'
             container:
               image: ghcr.io/homebrew/ubuntu22.04:master


### PR DESCRIPTION
This sees the final retirement of the non-ephemeral macOS CI.

I've also got a completely recreated 10.11-cross image that is picked up automatically here without any workflow changes but is being tested for the first time with the CI runs in this PR.