### PR TITLE
portable-ruby: fix more compiler toolchain references

### DIFF
--- a/Formula/portable-ruby.rb
+++ b/Formula/portable-ruby.rb
@@ -104,6 +104,8 @@ class PortableRuby < PortableFormula
       inreplace lib/"ruby/#{abi_version}/#{abi_arch}/rbconfig.rb" do |s|
         s.gsub! ENV.cxx, "c++"
         s.gsub! ENV.cc, "cc"
+        # Change e.g. `CONFIG["AR"] = "gcc-ar-11"` to `CONFIG["AR"] = "ar"`
+        s.gsub!(/(CONFIG\[".+"\] = )"gcc-(.*)-\d+"/, '\\1"\\2"')
         # C++ compiler might have been disabled because we break it with glibc@2.13 builds
         s.sub!(/(CONFIG\["CXX"\] = )"false"/, '\\1"c++"')
       end


### PR DESCRIPTION
We already get rid of the compiler shim references in `rbconfig.rb`, but there are still some more that may not be valid on the target system:

```console
$ brew ruby -e 'p RbConfig::CONFIG.select { |k, v| v.match? /gcc-(.*)-\d+/ }'
{"RANLIB"=>"gcc-ranlib-11", "NM"=>"gcc-nm-11", "AR"=>"gcc-ar-11"}
```

We can replace them with `ranlib`, `nm`, and `ar`, respectively.

This should help to avoid issues like the one spotted in Homebrew/brew#17114.
