### PR TITLE
Add livecheck blocks to formulae

### DIFF
--- a/Formula/portable-libffi.rb
+++ b/Formula/portable-libffi.rb
@@ -7,6 +7,11 @@ class PortableLibffi < PortableFormula
   sha256 "b0dea9df23c863a7a50e825440f3ebffabd65df1497108e5d437747843895a4e"
   license "MIT"
 
+  livecheck do
+    url :stable
+    strategy :github_latest
+  end
+
   def install
     system "./configure", *portable_configure_args,
                           *std_configure_args,

--- a/Formula/portable-libxcrypt.rb
+++ b/Formula/portable-libxcrypt.rb
@@ -7,6 +7,11 @@ class PortableLibxcrypt < PortableFormula
   sha256 "e5e1f4caee0a01de2aee26e3138807d6d3ca2b8e67287966d1fefd65e1fd8943"
   license "LGPL-2.1-or-later"
 
+  livecheck do
+    url :stable
+    strategy :github_latest
+  end
+
   def install
     system "./configure", *portable_configure_args,
                           *std_configure_args,

--- a/Formula/portable-libyaml.rb
+++ b/Formula/portable-libyaml.rb
@@ -7,6 +7,11 @@ class PortableLibyaml < PortableFormula
   sha256 "c642ae9b75fee120b2d96c712538bd2cf283228d2337df2cf2988e3c02678ef4"
   license "MIT"
 
+  livecheck do
+    url :stable
+    strategy :github_latest
+  end
+
   def install
     system "./configure", *portable_configure_args,
                           "--disable-dependency-tracking",

--- a/Formula/portable-openssl.rb
+++ b/Formula/portable-openssl.rb
@@ -9,6 +9,11 @@ class PortableOpenssl < PortableFormula
   sha256 "53e66b043322a606abf0087e7699a0e033a37fa13feb9742df35c3a33b18fb02"
   license "Apache-2.0"
 
+  livecheck do
+    url "https://www.openssl.org/source/"
+    regex(/href=.*?openssl[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
+
   resource "cacert" do
     # https://curl.se/docs/caextract.html
     url "https://curl.se/ca/cacert-2024-03-11.pem"

--- a/Formula/portable-ruby.rb
+++ b/Formula/portable-ruby.rb
@@ -7,6 +7,11 @@ class PortableRuby < PortableFormula
   sha256 "8dc2af2802cc700cd182d5430726388ccf885b3f0a14fcd6a0f21ff249c9aa99"
   license "Ruby"
 
+  livecheck do
+    url "https://www.ruby-lang.org/en/downloads/releases/"
+    regex(/href=.*?ruby[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
+
   depends_on "pkg-config" => :build
   depends_on "portable-libyaml" => :build
   depends_on "portable-openssl" => :build

--- a/Formula/portable-zlib.rb
+++ b/Formula/portable-zlib.rb
@@ -10,6 +10,11 @@ class PortableZlib < PortableFormula
   sha256 "9a93b2b7dfdac77ceba5a558a580e74667dd6fede4585b91eefb60f03b72df23"
   license "Zlib"
 
+  livecheck do
+    url :homepage
+    regex(/href=.*?zlib[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
+
   # https://zlib.net/zlib_how.html
   resource "test_artifact" do
     url "https://zlib.net/zpipe.c"


### PR DESCRIPTION
As discussed in https://github.com/Homebrew/homebrew-portable-ruby/issues/203, this adds `livecheck` blocks to the formulae in this tap. The `portable-ruby` `livecheck` block returns the newest stable version, assuming that the version restriction will be handled in any associated workflow. If we end up needing to handle the version restriction in the `livecheck` block, I can update this or create a follow-up PR.

One other thing worth noting is that the `livecheck` block for `portable-openssl` is checking the latest release on GitHub whereas the formula in homebrew/core checks https://www.openssl.org/source/. Should we align the check with the core formula(e)?