### PR TITLE
workflows/autobump: fix list collection

### DIFF
--- a/.github/workflows/autobump.yml
+++ b/.github/workflows/autobump.yml
@@ -40,7 +40,7 @@ jobs:
 
       - name: Get list of autobump portable-ruby formulae
         id: autobump
-        run: echo "autobump_list=$(brew tap-info --json "${GITHUB_REPOSITORY}" | jq -r '.[].formula_names[]')" >> "$GITHUB_OUTPUT"
+        run: echo "autobump_list=$(brew tap-info --json "${GITHUB_REPOSITORY}" | jq -r '.[].formula_names|join(" ")')" >> "$GITHUB_OUTPUT"
 
       - name: Bump portable-ruby formulae
         uses: Homebrew/actions/bump-packages@master


### PR DESCRIPTION
`jq` by default prints newlines but we were using the single-line `GITHUB_OUTPUT` syntax