### PR TITLE
workflows/release: set tag title.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -85,7 +85,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ github.token }}
         run: |
-          gh release create "${TAG}" --notes "Portable Ruby ${TAG}" --target "$(git rev-parse --verify HEAD)"
+          gh release create "${TAG}" --notes "Portable Ruby ${TAG}" --target "$(git rev-parse --verify HEAD)" --title "${TAG}"
 
       - name: Upload to GitHub Releases
         working-directory: bottles


### PR DESCRIPTION
Otherwise it defaults to the large merge commit message which is yuck.