### PR TITLE
Build fixes for ARM

### DIFF
--- a/Abstract/portable-formula.rb
+++ b/Abstract/portable-formula.rb
@@ -82,8 +82,12 @@ class PortableFormula < Formula
       keg_only "portable formulae are keg-only"
 
       on_linux do
-        depends_on "glibc@2.13" => :build
-        depends_on "linux-headers@4.4" => :build
+        on_intel do
+          depends_on "glibc@2.13" => :build
+          depends_on "linux-headers@4.4" => :build
+        end
+        # When we move from Ubuntu 22.04, on ARM we should add a dependency to glibc@2.35 and linux-headers@5.15.
+        # When doing so, remember to update the C++ Intel conditional in the portable-ruby formula.
       end
 
       prepend PortableFormulaMixin

--- a/Formula/portable-openssl.rb
+++ b/Formula/portable-openssl.rb
@@ -73,6 +73,7 @@ class PortableOpenssl < PortableFormula
       no-legacy
       no-module
       no-shared
+      no-engine
     ]
   end
 

--- a/Formula/portable-ruby.rb
+++ b/Formula/portable-ruby.rb
@@ -97,7 +97,7 @@ class PortableRuby < PortableFormula
         # Change e.g. `CONFIG["AR"] = "gcc-ar-11"` to `CONFIG["AR"] = "ar"`
         s.gsub!(/(CONFIG\[".+"\] = )"gcc-(.*)-\d+"/, '\\1"\\2"')
         # C++ compiler might have been disabled because we break it with glibc@2.13 builds
-        s.sub!(/(CONFIG\["CXX"\] = )"false"/, '\\1"c++"')
+        s.sub!(/(CONFIG\["CXX"\] = )"false"/, '\\1"c++"') if Hardware::CPU.intel?
       end
     end
 


### PR DESCRIPTION
Thanks to Apple Silicon, testing whether a Portable Ruby builds in a Linux ARM container takes just a few minutes.

* Scope glibc@2.13 reqiurement to Linux only
  - This effectively means that ARM support will require glibc 2.35 as a minimum, which seems reasonable to start clean for a new architecture and worry about our glibc formulae later down the line.
* portable-openssl: disable afalgeng
  - The test for it seems to fail in aarch64 containers. It might not necessarily will have in a theoretical future CI but it's not a feature we ever use so I opted to disable the feature entirely (Ruby's openssl gem does not allow engines to be enabled when using OpenSSL >=3.0).
  - All engines in general are deprecated in OpenSSL itself anyway afaik. Given the Ruby gem dropped support already, maybe we can slim the build further and just do `no-engine`?