### PR TITLE
Fix shellcheck issues

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,7 +79,7 @@ jobs:
         env:
           HOMEBREW_GITHUB_PACKAGES_USER: ${{ github.actor }}
           HOMEBREW_GITHUB_PACKAGES_TOKEN: ${{ github.token }}
-        run: brew pr-upload --debug --upload-only --root-url=https://ghcr.io/v2/${GITHUB_REPOSITORY_OWNER,,}/portable-ruby
+        run: brew pr-upload --debug --upload-only --root-url="https://ghcr.io/v2/${GITHUB_REPOSITORY_OWNER,,}/portable-ruby"
 
       - name: Push tag
         env:
@@ -91,7 +91,7 @@ jobs:
         working-directory: bottles
         env:
           HOMEBREW_GITHUB_API_TOKEN: ${{ github.token }}
-        run: brew pr-upload --debug --upload-only --root-url=https://github.com/${GITHUB_REPOSITORY}/releases/download/${TAG}
+        run: brew pr-upload --debug --upload-only --root-url="https://github.com/${GITHUB_REPOSITORY}/releases/download/${TAG}"
 
       - name: Cleanup
         run: rm -rvf bottles


### PR DESCRIPTION
`shellcheck` is reporting [SC2086](https://www.shellcheck.net/wiki/SC2086) ("Double quote to prevent globbing and word splitting") issues in the `release.yml` workflow. This adds quotes around the related areas to resolve the issues.

There's still one remaining actionlint issue in `build.yml` but it may be a false positive (as described in https://github.com/Homebrew/brew/pull/17482#issuecomment-2163812497):

```
homebrew-portable-ruby/.github/workflows/build.yml:27:16: object, array, and null values should not be evaluated in template with ${{ }} but evaluating the value of type {image: string; options: string} [expression]
   |
27 |     container: ${{matrix.container}}
   |                ^~~~~~~~~~~~~~~~~~~~~
```

Related to https://github.com/Homebrew/brew/pull/17482