### PR TITLE
portable-openssl: update cacert resource

### DIFF
--- a/Formula/portable-openssl.rb
+++ b/Formula/portable-openssl.rb
@@ -28,8 +28,8 @@ class PortableOpenssl < PortableFormula
 
   resource "cacert" do
     # https://curl.se/docs/caextract.html
-    url "https://curl.se/ca/cacert-2024-03-11.pem"
-    sha256 "1794c1d4f7055b7d02c2170337b61b48a2ef6c90d77e95444fd2596f4cac609f"
+    url "https://curl.se/ca/cacert-2024-07-02.pem"
+    sha256 "1bf458412568e134a4514f5e170a328d11091e071c7110955c9884ed87972ac9"
 
     livecheck do
       url "https://curl.se/ca/cadate.t"


### PR DESCRIPTION
Bumping to the resource to the latest version.