### PR TITLE
cmd/portable-package: add missing requires.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,7 +10,6 @@ updates:
   - dependency-type: all
   ignore:
   - dependency-name: actions/stale
-  - dependency-name: dessant/lock-threads
   groups:
     artifacts:
       patterns:

--- a/cmd/portable-package.rb
+++ b/cmd/portable-package.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 require "abstract_command"
+require "development_tools"
+require "dependency"
 
 module Homebrew
   module Cmd


### PR DESCRIPTION
These were no longer required by default in Homebrew/brew for speed.