### PR TITLE
cmd/portable-package: Enable Sorbet at `typed: strict` level

### DIFF
--- a/cmd/portable-package.rb
+++ b/cmd/portable-package.rb
@@ -1,3 +1,4 @@
+# typed: strict
 # frozen_string_literal: true
 
 require "abstract_command"
@@ -20,6 +21,7 @@ module Homebrew
         named_args :formula, min: 1
       end
 
+      sig { override.void }
       def run
         ENV["HOMEBREW_DEVELOPER"] = "1"
 

--- a/cmd/portable-package.rbi
+++ b/cmd/portable-package.rbi
@@ -1,0 +1,11 @@
+# typed: strict
+
+class Homebrew::Cmd::PortablePackageCmd
+  sig { returns(Homebrew::Cmd::PortablePackageCmd::Args) }
+  def args; end
+end
+
+class Homebrew::Cmd::PortablePackageCmd::Args < Homebrew::CLI::Args
+  sig { returns(T::Boolean) }
+  def no_uninstall_deps?; end
+end


### PR DESCRIPTION
- Part of https://github.com/Homebrew/brew/issues/17297