### PR TITLE
workflows/build: fix actionlint failure

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,13 +18,11 @@ jobs:
           - os: '10.11-cross-${{github.run_id}}'
           - os: '11-arm64-cross-${{github.run_id}}'
           - os: 'ubuntu-latest'
-            container:
-              image: ghcr.io/homebrew/ubuntu22.04:master
-              options: --user=linuxbrew
+            container: '{"image": "ghcr.io/homebrew/ubuntu22.04:master", "options": "--user=linuxbrew"}'
             workdir: /github/home
       fail-fast: false
     runs-on: ${{matrix.os}}
-    container: ${{matrix.container}}
+    container: ${{matrix.container && fromJSON(matrix.container) || ''}}
     defaults:
       run:
         working-directory: ${{matrix.workdir || github.workspace}}


### PR DESCRIPTION
We currently `-ignore` this error, but that's not very ergonomic because
it means you don't get the same results as our CI checks if you run
`actionlint` directly and forget to pass the right `-ignore` flags.

I tried pushing this to #248 but the sync-shared-config workflow keeps
overwriting my fix.
