### PR TITLE
ci: use ubuntu-latest

### DIFF
--- a/.github/workflows/autobump.yml
+++ b/.github/workflows/autobump.yml
@@ -21,7 +21,7 @@ permissions:
 jobs:
   autobump:
     if: github.repository_owner == 'Homebrew'
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     container:
       image: ghcr.io/homebrew/ubuntu22.04:master
     steps:


### PR DESCRIPTION
Align CI setup with what has been done in https://github.com/Homebrew/brew/pull/18704
Use ubuntu-latest when the ubuntu version does not matter.
ubuntu-latest is equivalent to 22.04 right now so this does not change anything

Our ubuntu 22.04 docker image is still used (this has not been modified)