### PR TITLE
workflows/tests: fix `template-injection` warning

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -34,4 +34,7 @@ jobs:
     if: github.event_name != 'push' && !cancelled()
     steps:
       - name: Result
-        run: ${{ needs.build.result == 'success' }}
+        env:
+          RESULT: ${{ needs.build.result }}
+        run: |
+          [[ "${RESULT}" == success ]]


### PR DESCRIPTION
Fixes https://github.com/Homebrew/homebrew-portable-ruby/security/code-scanning/1

This may not warn anymore on the latest version of `zizmor`, but I would
like to be able to run `zizmor` with `--pedantic`, and that will produce
a warning here.

It's simple enough to avoid, so let's just do that.
