### PR TITLE
workflows: use full version numbers

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,7 +41,7 @@ jobs:
           brew portable-package --verbose portable-ruby
 
       - name: Upload Portable Ruby
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
         with:
           name: bottles_${{matrix.os}}
           path: ${{matrix.workdir || github.workspace}}/bottle

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,7 +68,7 @@ jobs:
         run: mkdir bottles
 
       - name: Download bottles
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
         with:
           pattern: bottles_*
           path: bottles


### PR DESCRIPTION
This helps with transparency and they get updated by Dependabot.