### PR TITLE
portable-zlib: skip resource livecheck

### DIFF
--- a/Formula/portable-zlib.rb
+++ b/Formula/portable-zlib.rb
@@ -19,6 +19,10 @@ class PortableZlib < PortableFormula
     url "https://zlib.net/zpipe.c"
     version "20051211"
     sha256 "68140a82582ede938159630bca0fb13a93b4bf1cb2e85b08943c26242cf8f3a6"
+
+    livecheck do
+      skip "Static test artifact"
+    end
   end
 
   def install


### PR DESCRIPTION
Livecheck is currently returning `Unable to get versions` for this formula's resource. Given that it's a static file that won't be updated, let's skip checking it.