### PR TITLE
workflows/build: remove bootstrap steps

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,8 +21,9 @@ jobs:
             container: '{"image": "ghcr.io/homebrew/ubuntu22.04:master", "options": "--user=linuxbrew"}'
             workdir: /github/home
           - os: ubuntu-22.04-arm
-            container: '{"image": "rubylang/ruby:3.3.7-jammy"}'
-            bootstrap: true
+            container: '{"image": "ghcr.io/homebrew/ubuntu22.04:master", "options": "--user=linuxbrew"}'
+            workdir: /github/home
+            allow-only-setup-failure: true
       fail-fast: false
     runs-on: ${{matrix.os}}
     container: ${{matrix.container && fromJSON(matrix.container) || ''}}
@@ -30,23 +31,13 @@ jobs:
       run:
         working-directory: ${{matrix.workdir || github.workspace}}
     steps:
-      - name: Bootstrap
-        if: matrix.bootstrap
-        run: |
-          apt-get update
-          apt-get install -y --no-install-recommends curl git g++ make gawk patch
-          mkdir -p /home/linuxbrew/.linuxbrew/bin
-          git clone https://github.com/Homebrew/brew /home/linuxbrew/.linuxbrew/Homebrew
-          ln -s ../Homebrew/bin/brew /home/linuxbrew/.linuxbrew/bin/brew
-          echo "/home/linuxbrew/.linuxbrew/bin" >>"${GITHUB_PATH}"
-
       - name: Set up Homebrew
         uses: Homebrew/actions/setup-homebrew@master
 
       - run: brew test-bot --only-cleanup-before
 
       - run: brew test-bot --only-setup
-        if: ${{!matrix.bootstrap}}
+        continue-on-error: ${{ matrix.allow-only-setup-failure }}
 
       - name: Build Portable Ruby
         run: |


### PR DESCRIPTION
This should no longer be needed.
