### PR TITLE
portable-openssl: bump cacert resource

### DIFF
--- a/Formula/portable-openssl.rb
+++ b/Formula/portable-openssl.rb
@@ -28,8 +28,8 @@ class PortableOpenssl < PortableFormula
 
   resource "cacert" do
     # https://curl.se/docs/caextract.html
-    url "https://curl.se/ca/cacert-2025-07-15.pem"
-    sha256 "7430e90ee0cdca2d0f02b1ece46fbf255d5d0408111f009638e3b892d6ca089c"
+    url "https://curl.se/ca/cacert-2025-08-12.pem"
+    sha256 "64dfd5b1026700e0a0a324964749da9adc69ae5e51e899bf16ff47d6fd0e9a5e"
 
     livecheck do
       url "https://curl.se/ca/cadate.t"


### PR DESCRIPTION
Bumping to the latest `cacert` version.