### PR TITLE
workflows/build: use 10.15 for x86_64 Ruby.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         include:
-          - os: 10.11-cross-${{github.run_id}}
+          - os: 10.15-${{github.run_id}}
           - os: 11-arm64-cross-${{github.run_id}}
           - os: ubuntu-latest
             container: '{"image": "ghcr.io/homebrew/ubuntu22.04:main", "options": "--user=linuxbrew"}'


### PR DESCRIPTION
We're dropping support for 10.11-10.14 soon so let's try this out.