### PR TITLE
workflows: remove `test-bot` Action inputs

### DIFF
--- a/.github/workflows/autobump.yml
+++ b/.github/workflows/autobump.yml
@@ -31,7 +31,6 @@ jobs:
         with:
           core: false
           cask: false
-          test-bot: false
 
       - name: Configure Git user
         uses: Homebrew/actions/git-user-config@main

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,8 +18,6 @@ jobs:
     steps:
       - name: Set up Homebrew
         uses: Homebrew/actions/setup-homebrew@main
-        with:
-          test-bot: false
 
       - name: Determine tag
         id: determine-tag
@@ -52,8 +50,6 @@ jobs:
     steps:
       - name: Set up Homebrew
         uses: Homebrew/actions/setup-homebrew@main
-        with:
-          test-bot: false
 
       - name: Checkout branch
         run: git checkout "${GITHUB_REF_NAME}"


### PR DESCRIPTION
`test-bot` has been merged into Homebrew/brew, so this is no longer necessary and outputs a warning in CI.

---

- https://github.com/Homebrew/brew/pull/20762